### PR TITLE
Activate Link: Attempts to delete the plugin

### DIFF
--- a/shiny-updates.php
+++ b/shiny-updates.php
@@ -159,10 +159,10 @@ class Shiny_Updates {
 		}
 
 		// Adjust the activate action, adding data attributes.
-		if ( ! empty( $actions['activate'] ) ) {
+		/*if ( ! empty( $actions['activate'] ) ) {
 			$slug = empty( $plugin_data['slug'] ) ? dirname( $plugin_file ) : $plugin_data['slug'];
 			$actions['activate'] = '<a data-plugin="' . $plugin_file . '" data-slug="' . $slug . '" href="' . wp_nonce_url( 'plugins.php?action=activate-selected&amp;checked[]=' . $plugin_file . '&amp;plugin_status=' . $context . '&amp;paged=' . $GLOBALS['page'] . '&amp;s=' . $GLOBALS['s'], 'bulk-plugins' ) . '" class="edit" aria-label="' . esc_attr( sprintf( __( 'Activate %s' ), $plugin_data['Name'] ) ) . '">' . __( 'Activate' ) . '</a>';
-		}
+		}*/
 
 		return $actions;
 	}

--- a/shiny-updates.php
+++ b/shiny-updates.php
@@ -161,7 +161,7 @@ class Shiny_Updates {
 		// Adjust the activate action, adding data attributes.
 		if ( ! empty( $actions['activate'] ) ) {
 			$slug = empty( $plugin_data['slug'] ) ? dirname( $plugin_file ) : $plugin_data['slug'];
-			$actions['activate'] = '<a data-plugin="' . $plugin_file . '" data-slug="' . $slug . '" href="' . wp_nonce_url( 'plugins.php?action=delete-selected&amp;checked[]=' . $plugin_file . '&amp;plugin_status=' . $context . '&amp;paged=' . $GLOBALS['page'] . '&amp;s=' . $GLOBALS['s'], 'bulk-plugins' ) . '" class="edit" aria-label="' . esc_attr( sprintf( __( 'Activate %s' ), $plugin_data['Name'] ) ) . '">' . __( 'Activate' ) . '</a>';
+			$actions['activate'] = '<a data-plugin="' . $plugin_file . '" data-slug="' . $slug . '" href="' . wp_nonce_url( 'plugins.php?action=activate-selected&amp;checked[]=' . $plugin_file . '&amp;plugin_status=' . $context . '&amp;paged=' . $GLOBALS['page'] . '&amp;s=' . $GLOBALS['s'], 'bulk-plugins' ) . '" class="edit" aria-label="' . esc_attr( sprintf( __( 'Activate %s' ), $plugin_data['Name'] ) ) . '">' . __( 'Activate' ) . '</a>';
 		}
 
 		return $actions;


### PR DESCRIPTION
The `action` for the "Activate" link is filtered to `delete-selected`, so changes this to the expected.

At the same time, it doesn't appear any of the JS to actually activate a plugin is in the plugin yet, so disabling the filtering by commenting out the code for the immediate.

This PR makes the plugin usable to activate plugins for the time being. :)