### PR TITLE
Add JSCS with WordPress coding standards to build process

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,13 +24,22 @@ module.exports = function(grunt) {
 		watch: {
 			files: ['<%= jshint.files %>'],
 			tasks: ['jshint', 'qunit']
+		},
+		jscs: {
+			src: 'js/**/*.js',
+				options: {
+					config: '.jscsrc',
+					verbose: true,
+					preset: 'wordpress'
+				}
 		}
 	});
 
 	grunt.loadNpmTasks('grunt-contrib-jshint');
 	grunt.loadNpmTasks('grunt-contrib-qunit');
 	grunt.loadNpmTasks('grunt-contrib-watch');
+	grunt.loadNpmTasks( 'grunt-jscs' );
 
-	grunt.registerTask('default', ['jshint', 'qunit']);
+	grunt.registerTask('default', ['jshint', 'jscs', 'qunit']);
 
 };

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "grunt": "~0.4.5",
     "grunt-contrib-jshint": "~0.11.3",
     "grunt-contrib-qunit": "~0.7.0",
-    "grunt-contrib-watch": "~0.6.1"
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-jscs": "^2.5.0"
   }
 }


### PR DESCRIPTION
* See http://jscs.info/