### PR TITLE
Enable enqueueing of multiple updates/installs from `plugin-install.php`

### DIFF
--- a/js/shiny-updates.js
+++ b/js/shiny-updates.js
@@ -90,11 +90,12 @@ window.wp = window.wp || {};
 			$card.removeClass( 'plugin-card-update-failed' ).find( '.notice.notice-error' ).remove();
 		}
 
+		$message.addClass( 'updating-message' );
+
 		if ( ! wp.updates.updateLock ) {
 			message = wp.updates.l10n.updatingLabel.replace( '%s', name );
 			$message.attr( 'aria-label', message );
 
-			$message.addClass( 'updating-message' );
 			if ( $message.html() !== wp.updates.l10n.updating ) {
 				$message.data( 'originaltext', $message.html() );
 			}

--- a/js/shiny-updates.js
+++ b/js/shiny-updates.js
@@ -42,7 +42,7 @@ window.wp = window.wp || {};
 			private_key:     wp.updates.filesystemCredentials.ssh.privateKey
 		});
 
-		return wp.ajax.post( action, data );
+		return wp.ajax.post( action, data ).always( wp.updates.ajaxAlways );
 	};
 
 	/**
@@ -108,8 +108,7 @@ window.wp = window.wp || {};
 
 		wp.updates.ajax( 'update-plugin', { plugin: plugin, slug: slug } )
 			.done( wp.updates.updateSuccess )
-			.fail( wp.updates.updateError )
-			.always( wp.updates.ajaxAlways );
+			.fail( wp.updates.updateError );
 	};
 
 	/**
@@ -360,8 +359,7 @@ window.wp = window.wp || {};
 
 		wp.updates.ajax( 'install-plugin', { slug: slug } )
 			.done( wp.updates.installPluginSuccess )
-			.fail( wp.updates.installPluginError )
-			.always( wp.updates.ajaxAlways );
+			.fail( wp.updates.installPluginError );
 	};
 
 	/**
@@ -439,8 +437,7 @@ window.wp = window.wp || {};
 
 		wp.updates.ajax( 'delete-plugin', { plugin: plugin, slug: slug } )
 			.done( wp.updates.deletePluginSuccess )
-			.fail( wp.updates.deletePluginError )
-			.always( wp.updates.ajaxAlways );
+			.fail( wp.updates.deletePluginError );
 	};
 
 	/**
@@ -503,8 +500,7 @@ window.wp = window.wp || {};
 
 		wp.updates.ajax( 'update-theme', { 'slug': slug } )
 			.done( wp.updates.updateThemeSuccess )
-			.fail( wp.updates.updateThemeError )
-			.always( wp.updates.ajaxAlways );
+			.fail( wp.updates.updateThemeError );
 	};
 
 	/**
@@ -574,8 +570,7 @@ window.wp = window.wp || {};
 
 		wp.updates.ajax( 'install-theme', { 'slug': slug } )
 			.done( wp.updates.installThemeSuccess )
-			.fail( wp.updates.installThemeError )
-			.always( wp.updates.ajaxAlways );
+			.fail( wp.updates.installThemeError );
 	};
 
 	/**
@@ -651,8 +646,7 @@ window.wp = window.wp || {};
 
 		wp.updates.ajax( 'delete-theme', { 'slug': slug } )
 			.done( wp.updates.deleteThemeSuccess )
-			.fail( wp.updates.deleteThemeError )
-			.always( wp.updates.ajaxAlways );
+			.fail( wp.updates.deleteThemeError );
 	};
 
 	/**
@@ -907,7 +901,7 @@ window.wp = window.wp || {};
 		/**
 		 * Make notices dismissable.
  		 */
-		$document.on( 'wp-progress-updated wp-theme-update-error wp-theme-install-error', function() {
+		$( document ) .on( 'wp-progress-updated wp-theme-update-error wp-theme-install-error', function() {
 			$( '.notice.is-dismissible' ).each( function() {
 				var $el = $( this ),
 					$button = $( '<button type="button" class="notice-dismiss"><span class="screen-reader-text"></span></button>' ),

--- a/js/shiny-updates.js
+++ b/js/shiny-updates.js
@@ -42,7 +42,7 @@ window.wp = window.wp || {};
 			private_key:     wp.updates.filesystemCredentials.ssh.privateKey
 		});
 
-		return wp.ajax.post( action, data ).always( wp.updates.ajaxAlways );
+		return wp.ajax.post( action, data );
 	};
 
 	/**
@@ -107,7 +107,8 @@ window.wp = window.wp || {};
 
 		wp.updates.ajax( 'update-plugin', { plugin: plugin, slug: slug } )
 			.done( wp.updates.updateSuccess )
-			.fail( wp.updates.updateError );
+			.fail( wp.updates.updateError )
+			.always( wp.updates.ajaxAlways );
 	};
 
 	/**
@@ -358,7 +359,8 @@ window.wp = window.wp || {};
 
 		wp.updates.ajax( 'install-plugin', { slug: slug } )
 			.done( wp.updates.installPluginSuccess )
-			.fail( wp.updates.installPluginError );
+			.fail( wp.updates.installPluginError )
+			.always( wp.updates.ajaxAlways );
 	};
 
 	/**
@@ -436,7 +438,8 @@ window.wp = window.wp || {};
 
 		wp.updates.ajax( 'delete-plugin', { plugin: plugin, slug: slug } )
 			.done( wp.updates.deletePluginSuccess )
-			.fail( wp.updates.deletePluginError );
+			.fail( wp.updates.deletePluginError )
+			.always( wp.updates.ajaxAlways );
 	};
 
 	/**
@@ -499,7 +502,8 @@ window.wp = window.wp || {};
 
 		wp.updates.ajax( 'update-theme', { 'slug': slug } )
 			.done( wp.updates.updateThemeSuccess )
-			.fail( wp.updates.updateThemeError );
+			.fail( wp.updates.updateThemeError )
+			.always( wp.updates.ajaxAlways );
 	};
 
 	/**
@@ -569,7 +573,8 @@ window.wp = window.wp || {};
 
 		wp.updates.ajax( 'install-theme', { 'slug': slug } )
 			.done( wp.updates.installThemeSuccess )
-			.fail( wp.updates.installThemeError );
+			.fail( wp.updates.installThemeError )
+			.always( wp.updates.ajaxAlways );
 	};
 
 	/**
@@ -645,7 +650,8 @@ window.wp = window.wp || {};
 
 		wp.updates.ajax( 'delete-theme', { 'slug': slug } )
 			.done( wp.updates.deleteThemeSuccess )
-			.fail( wp.updates.deleteThemeError );
+			.fail( wp.updates.deleteThemeError )
+			.always( wp.updates.ajaxAlways );
 	};
 
 	/**
@@ -900,7 +906,7 @@ window.wp = window.wp || {};
 		/**
 		 * Make notices dismissable.
  		 */
-		$( document ) .on( 'wp-progress-updated wp-theme-update-error wp-theme-install-error', function() {
+		$document.on( 'wp-progress-updated wp-theme-update-error wp-theme-install-error', function() {
 			$( '.notice.is-dismissible' ).each( function() {
 				var $el = $( this ),
 					$button = $( '<button type="button" class="notice-dismiss"><span class="screen-reader-text"></span></button>' ),


### PR DESCRIPTION
* clicking on several buttons quickly adds them to the queue
* start showing progress spinner immediately after click so user knows action is occuring
* remove extraneous queue push, in wp.updates.ajax now