### PR TITLE
Remove `updateLock` handling in `updatePlugin()`.

### DIFF
--- a/js/shiny-updates.js
+++ b/js/shiny-updates.js
@@ -104,16 +104,7 @@ window.wp = window.wp || {};
 
 			$document.trigger( 'wp-plugin-updating' );
 		}
-		if ( wp.updates.updateLock ) {
-			wp.updates.updateQueue.push( {
-				type: 'update-plugin',
-				data: {
-					plugin: plugin,
-					slug: slug
-				}
-			} );
-			return;
-		}
+
 		wp.updates.ajax( 'update-plugin', { plugin: plugin, slug: slug } )
 			.done( wp.updates.updateSuccess )
 			.fail( wp.updates.updateError );


### PR DESCRIPTION
This is now handled in `wp.updates.ajax()` and was just a leftover from
ea259324cc05ff69b6dbb1fa494a19f09e4bc1ae.