### PR TITLE
Improved inline notifications.

### DIFF
--- a/shiny-updates.php
+++ b/shiny-updates.php
@@ -13,5 +13,6 @@
 
 include_once 'src/class-shiny-updates.php';
 include_once 'src/ajax-actions.php';
+include_once 'src/update.php';
 
 add_action( 'init', array( 'Shiny_Updates', 'init' ) );

--- a/src/class-shiny-updates.php
+++ b/src/class-shiny-updates.php
@@ -32,7 +32,7 @@ class Shiny_Updates {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
 		// Add the update HTML for plugin updates progress.
-		add_action( 'pre_current_active_plugins', array( $this, 'wp_update_notification_template' ) );
+		add_action( 'in_admin_header', array( $this, 'wp_admin_notice_template' ) );
 
 		// Search plugins.
 		add_action( 'wp_ajax_search-plugins', 'wp_ajax_search_plugins' );
@@ -81,20 +81,23 @@ class Shiny_Updates {
 
 	/**
 	 * Add the HTML template for progress updates.
+	 *
+	 * Template takes one argument with three values:
+	 *
+	 * param {object} data {
+	 *     Arguments for admin notice.
+	 *
+	 *     @type string id        ID of the notice.
+	 *     @type string className Class names for the notice.
+	 *     @type string message   The notice's message.
+	 * }
 	 */
-	function wp_update_notification_template() {
+	function wp_admin_notice_template() {
 		?>
-		<div id="wp-progress-placeholder"></div>
-		<script id="tmpl-wp-progress-template" type="text/html">
-			<div class="notice wp-progress-update is-dismissible <# if ( data.noticeClass ) { #> {{ data.noticeClass }} <# } #>">
-				<p>
-					<# if ( data.message ) { #>
-						{{ data.message }}
-						<# } #>
-				</p>
-			</div>
+		<script id="tmpl-wp-updates-admin-notice" type="text/html">
+			<div <# if ( data.id ) { #>id="{{ data.id }}"<# } #> class="notice {{ data.className }}"><p>{{ data.message }}</p></div>
 		</script>
-	<?php
+		<?php
 	}
 
 	/**
@@ -116,6 +119,7 @@ class Shiny_Updates {
 			'l10n'       => array(
 				'updating'                  => __( 'Updating...' ), // No ellipsis.
 				'updated'                   => __( 'Updated!' ),
+				'updateNow'                 => __( 'Update Now' ),
 				'updateFailedShort'         => __( 'Update Failed!' ),
 				/* translators: Error string for a failed update */
 				'updateFailed'              => __( 'Update Failed: %s' ),
@@ -146,17 +150,10 @@ class Shiny_Updates {
 				'installFailedLabel'        => __( '%s installation failed' ),
 				'installingMsg'             => __( 'Installing... please wait.' ),
 				'installedMsg'              => __( 'Installation completed successfully.' ),
-				'aysDelete'                 => __( 'Are you sure you want to delete this plugin?' ),
-				'deletinggMsg'              => __( 'Deleting... please wait.' ),
-				'deletedMsg'                => __( 'Plugin successfully deleted.' ),
-				'updatedPluginsMsg'         => __( 'Plugin updates complete.' ),
-				/* translators: 1. Plugins update successes. 2. Plugin update failures. */
-				'updatedPluginsSuccessMsg'  => __( 'Successes: %d.' ),
-				/* translators: 1. Plugins update successes. 2. Plugin update failures. */
-				'updatedPluginsFailureMsg'  => __( 'Failures: %d.' ),
-				/* translators: 1. Total plugins to update. */
-				'updatePluginsQueuedMsg'    => __( '%d plugin updates queued.' ),
-				'updateQueued'              => __( 'Update queued.' ),
+				'aysDelete'                 => __( 'Are you sure you want to delete this item?' ),
+				'deleting'                  => __( 'Deleting...' ),
+				'deleteFailed'              => __( 'Deletion failed: %s' ),
+				'deleted'                   => __( 'Deleted!' ),
 			),
 		) );
 

--- a/src/class-shiny-updates.php
+++ b/src/class-shiny-updates.php
@@ -117,6 +117,7 @@ class Shiny_Updates {
 		wp_localize_script( 'shiny-updates', '_wpUpdatesSettings', array(
 			'ajax_nonce' => wp_create_nonce( 'updates' ),
 			'l10n'       => array(
+				'noItemsSelected'           => __( 'Please select at least one item to perform this action on.' ),
 				'updating'                  => __( 'Updating...' ), // No ellipsis.
 				'updated'                   => __( 'Updated!' ),
 				'updateNow'                 => __( 'Update Now' ),

--- a/src/class-shiny-updates.php
+++ b/src/class-shiny-updates.php
@@ -97,6 +97,25 @@ class Shiny_Updates {
 		<script id="tmpl-wp-updates-admin-notice" type="text/html">
 			<div <# if ( data.id ) { #>id="{{ data.id }}"<# } #> class="notice {{ data.className }}"><p>{{{ data.message }}}</p></div>
 		</script>
+		<script id="tmpl-wp-bulk-updates-admin-notice" type="text/html">
+			<div id="{{ data.id }}" class="notice <# if ( data.errors ) { #>notice-error<# } else { #>notice-success<# } #>">
+				<p>
+					<# if ( data.successes ) { #>
+						<?php printf( __( '%s plugins successfully updated.' ), '{{ data.successes }}' ); ?>
+					<# } #>
+					<# if ( data.errors ) { #>
+						<button class="button-link"><?php printf( __( '%s failures.' ), '{{ data.errors }}' ); ?></button>
+					<# } #>
+				</p>
+				<# if ( data.errors ) { #>
+					<ul class="hidden">
+						<# _.each( data.errorMessages, function( errorMessage ) { #>
+							<li>{{ errorMessage }}</li>
+						<# } ); #>
+					</ul>
+				<# } #>
+			</div>
+		</script>
 		<?php
 	}
 

--- a/src/class-shiny-updates.php
+++ b/src/class-shiny-updates.php
@@ -129,13 +129,20 @@ class Shiny_Updates {
 			return;
 		}
 
+		$plugins = array();
+		foreach ( $GLOBALS['plugins'] as $key => $list ) {
+			$plugins[ $key ] = array_keys( (array) $list );
+		}
+
 		wp_enqueue_style( 'shiny-updates', plugin_dir_url( __FILE__ ) . 'css/shiny-updates.css' );
 
 		wp_dequeue_script( 'updates' );
 		wp_enqueue_script( 'shiny-updates', plugin_dir_url( __FILE__ ) . 'js/shiny-updates.js', array( 'jquery', 'wp-util', 'wp-a11y' ), null, true );
 		wp_localize_script( 'shiny-updates', '_wpUpdatesSettings', array(
 			'ajax_nonce' => wp_create_nonce( 'updates' ),
+			'plugins'    => $plugins,
 			'l10n'       => array(
+				'noPlugins'                 => __( 'You do not appear to have any plugins available at this time.' ),
 				'noItemsSelected'           => __( 'Please select at least one item to perform this action on.' ),
 				'updating'                  => __( 'Updating...' ), // No ellipsis.
 				'updated'                   => __( 'Updated!' ),

--- a/src/class-shiny-updates.php
+++ b/src/class-shiny-updates.php
@@ -95,7 +95,7 @@ class Shiny_Updates {
 	function wp_admin_notice_template() {
 		?>
 		<script id="tmpl-wp-updates-admin-notice" type="text/html">
-			<div <# if ( data.id ) { #>id="{{ data.id }}"<# } #> class="notice {{ data.className }}"><p>{{ data.message }}</p></div>
+			<div <# if ( data.id ) { #>id="{{ data.id }}"<# } #> class="notice {{ data.className }}"><p>{{{ data.message }}}</p></div>
 		</script>
 		<?php
 	}

--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -59,19 +59,37 @@
 }
 
 /* Inline notifications */
-.plugins .update td,
-.plugins .update th,
-.plugins tr.active + tr.inactive.update th,
-.plugins tr.active + tr.inactive.update td,
-.plugins tr.active + tr.inactive.updated th,
-.plugins tr.active + tr.inactive.updated td {
-	-webkit-box-shadow: inset 0 -1px 0 rgba(0,0,0,0.1);
-	box-shadow: inset 0 -1px 0 rgba(0,0,0,0.1);
+.plugins .active.update th.check-column,
+.plugins .active.update + .plugin-update-tr .plugin-update {
+	border-left: 4px solid #00a0d2;
+}
+
+.plugins .active.update td,
+.plugins .active.update th,
+tr.active.update + tr.plugin-update-tr .plugin-update {
+	background-color: #f7fcfe;
+}
+
+tr.active + tr.plugin-update-tr:not(.updated) .plugin-update .update-message {
+	background-color: #fff8e5;
+}
+
+.plugin-update-tr .update-message {
+	margin: 5px 20px 15px 31px;
+	padding: 1px 12px 1px 40px;
+}
+
+.plugin-update-tr .update-message:before {
+	content: '';
+	display: none;
+	margin: auto;
+}
+
+.widefat td p {
+	margin: 0.5em 0;
 }
 
 .update-message {
-	background-color: #f7f7f7;
-	background-color: rgba(0,0,0,0.03);
 	padding-left: 40px;
 }
 
@@ -126,4 +144,38 @@
 .notice .button-link:hover,
 .notice .button-link:active {
 	color: #00a0d2;
+}
+
+.notice-success,
+div.updated {
+	border-left-color: #46b450;
+}
+
+.notice-success.notice-alt {
+	background-color: #ecf7ed;
+}
+
+.notice-warning {
+	border-left-color: #ffb900;
+}
+
+.notice-warning.notice-alt {
+	background-color: #fff8e5;
+}
+
+.notice-error,
+div.error {
+	border-left-color: #dc3232;
+}
+
+.notice-error.notice-alt {
+	background-color: #fbeaea;
+}
+
+.notice-info {
+	border-left-color: #00a0d2;
+}
+
+.notice-info.notice-alt {
+	background-color: #e5f5fa;
 }

--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -23,10 +23,6 @@
 	content: '\f147';
 }
 
-.plugin-update-tr .update-message.update-error-message:before {
-	content: "\f158";
-}
-
 .theme-install-php .theme .notice-error {
 	display: block;
 	left: 0;
@@ -59,4 +55,49 @@
 	speak: none;
 	margin: 0 8px 0 -2px;
 	vertical-align: top;
+}
+
+/* Inline notifications */
+
+.update-message {
+	background-color: #f7f7f7;
+	background-color: rgba(0,0,0,0.03);
+	padding-left: 40px;
+}
+
+.column-description .update-message p {
+	margin: 0.5em 0;
+	padding: 2px;
+}
+
+.update-message p:before {
+	color: #d54e21;
+	display: inline-block;
+	font: normal 20px/1 dashicons;
+	content: "\f463";
+	margin: 0 10px 0 -30px;
+	speak: none;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	vertical-align: top;
+}
+
+.updating-message p:before {
+	content: "\f463";
+	-webkit-animation: rotation 2s infinite linear;
+	animation: rotation 2s infinite linear;
+}
+
+.wrap .notice-success p:before {
+	color: #79ba49;
+	content: "\f147";
+}
+
+.wrap .notice-error p:before {
+	content: "\f534";
+}
+
+.plugin-card .update-message p:before {
+	content: '';
+	margin: auto;
 }

--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -1,3 +1,4 @@
+.wrap .notice p:before,
 .theme-info .updating-message::before,
 .theme-info .updated-message::before,
 .theme-install.updating-message::before {
@@ -101,6 +102,7 @@
 }
 
 .wrap .notice-error p:before {
+	color: #dc3232;
 	content: "\f534";
 }
 

--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -110,3 +110,19 @@
 	content: '';
 	margin: auto;
 }
+
+
+.notice .button-link {
+	color: #0073aa;
+	-webkit-transition-property: border, background, color;
+	transition-property: border, background, color;
+	-webkit-transition-duration: .05s;
+	transition-duration: .05s;
+	-webkit-transition-timing-function: ease-in-out;
+	transition-timing-function: ease-in-out;
+}
+
+.notice .button-link:hover,
+.notice .button-link:active {
+	color: #00a0d2;
+}

--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -59,6 +59,8 @@
 }
 
 /* Inline notifications */
+.plugins .update td,
+.plugins .update th,
 .plugins tr.active + tr.inactive.update th,
 .plugins tr.active + tr.inactive.update td,
 .plugins tr.active + tr.inactive.updated th,
@@ -110,7 +112,6 @@
 	content: '';
 	margin: auto;
 }
-
 
 .notice .button-link {
 	color: #0073aa;

--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -58,6 +58,13 @@
 }
 
 /* Inline notifications */
+.plugins tr.active + tr.inactive.update th,
+.plugins tr.active + tr.inactive.update td,
+.plugins tr.active + tr.inactive.updated th,
+.plugins tr.active + tr.inactive.updated td {
+	-webkit-box-shadow: inset 0 -1px 0 rgba(0,0,0,0.1);
+	box-shadow: inset 0 -1px 0 rgba(0,0,0,0.1);
+}
 
 .update-message {
 	background-color: #f7f7f7;

--- a/src/js/shiny-theme-updates.js
+++ b/src/js/shiny-theme-updates.js
@@ -79,6 +79,8 @@ window.wp = window.wp || {};
 		},
 
 		deleteTheme: function( event ) {
+			var _this = this,
+				_collection = _this.model.collection;
 			event.preventDefault();
 
 			// Confirmation dialog for deleting a theme.
@@ -89,6 +91,15 @@ window.wp = window.wp || {};
 			if ( wp.updates.shouldRequestFilesystemCredentials && ! wp.updates.updateLock ) {
 				wp.updates.requestFilesystemCredentials( event );
 			}
+
+			$( document ).one( 'wp-delete-theme-success', function( event, response ) {
+				_this.$el.find( '.close' ).trigger( 'click' );
+				$( '#' + response.slug ).css( { backgroundColor:'#faafaa' } ).fadeOut( 350, function() {
+					$( this ).remove();
+					_collection.remove( _this.model );
+					_collection.trigger( 'update' );
+				} );
+			} );
 
 			wp.updates.deleteTheme( this.model.get( 'id' ) );
 		}
@@ -107,11 +118,11 @@ window.wp = window.wp || {};
 		},
 
 		installTheme: function( event ) {
-			var _this  = this,
-				target = $( event.target );
+			var _this   = this,
+				$target = $( event.target );
 			event.preventDefault();
 
-			if ( target.hasClass( 'disabled' ) ) {
+			if ( $target.hasClass( 'disabled' ) ) {
 				return;
 			}
 
@@ -123,7 +134,7 @@ window.wp = window.wp || {};
 				_this.model.set( { 'installed': true } );
 			} );
 
-			wp.updates.installTheme( $( event.target ).data( 'slug' ) );
+			wp.updates.installTheme( $target.data( 'slug' ) );
 		}
 	} );
 

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -1146,7 +1146,7 @@ window.wp = window.wp || {};
 		$bulkActionForm.on( 'click', '[type="submit"]', function( event ) {
 			var action        = $( event.target ).siblings( 'select' ).val(),
 				itemsSelected = $bulkActionForm.find( 'input[name="checked[]"]:checked' ),
-				pluginAction;
+				pluginAction, success = 0, error = 0, errorMessages = [];
 
 			if ( 'plugins' !== pagenow && 'plugins-network' !== pagenow ) {
 				return;
@@ -1199,6 +1199,30 @@ window.wp = window.wp || {};
 				}
 
 				pluginAction( $pluginRow.data( 'plugin' ), $pluginRow.data( 'slug' ) );
+			} );
+
+			$document.on( 'wp-plugin-update-success', function() {
+				success++;
+			} );
+
+			$document.on( 'wp-plugin-update-error', function( event, response ) {
+				error++;
+				errorMessages.push( response.pluginName + ': ' + response.error );
+			} );
+
+			$document.on( 'wp-plugin-update-success wp-plugin-update-error', function() {
+				wp.updates.adminNotice = wp.template( 'wp-bulk-updates-admin-notice' );
+
+				wp.updates.addAdminNotice( {
+					id: 'bulk-action-notice',
+					successes: success,
+					errors: error,
+					errorMessages: errorMessages
+				} );
+
+				$( '#bulk-action-notice' ).on( 'click', 'button', function() {
+					$( '#bulk-action-notice' ).find( 'ul' ).toggleClass( 'hidden' );
+				} );
 			} );
 		} );
 

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -161,7 +161,7 @@ window.wp = window.wp || {};
 			connection_type: wp.updates.filesystemCredentials.ftp.connectionType,
 			public_key:      wp.updates.filesystemCredentials.ssh.publicKey,
 			private_key:     wp.updates.filesystemCredentials.ssh.privateKey
-		});
+		} );
 
 		return wp.ajax.post( action, data ).always( wp.updates.ajaxAlways );
 	};
@@ -643,7 +643,7 @@ window.wp = window.wp || {};
 	wp.updates.installThemeError = function( response ) {
 		var $card, $button,
 			errorMessage = wp.updates.l10n.installFailed.replace( '%s', response.error ),
-			$message     = wp.updates.adminNotice({ className: 'update-message notice-error notice-alt', message: errorMessage });
+			$message     = wp.updates.adminNotice( { className: 'update-message notice-error notice-alt', message: errorMessage } );
 
 		if ( response.errorCode && 'unable_to_connect_to_filesystem' === response.errorCode ) {
 			wp.updates.credentialError( response, 'install-theme' );
@@ -922,6 +922,7 @@ window.wp = window.wp || {};
 				slug: response.slug
 			}
 		} );
+
 		wp.updates.filesystemCredentials.available = false;
 		wp.updates.showErrorInCredentialsForm( response.error );
 		wp.updates.requestFilesystemCredentials();
@@ -977,7 +978,7 @@ window.wp = window.wp || {};
 			wp.updates.queueChecker();
 
 			return false;
-		});
+		} );
 
 		/**
 		 * Close the request credentials modal when clicking the 'Cancel' button or outside of he modal.
@@ -1001,7 +1002,7 @@ window.wp = window.wp || {};
 
 			$pluginRow.find( '.column-description' ).prepend( wp.updates.adminNotice({ className: 'update-message notice-warning notice-alt', message: $element.find( '.update-message p' ).html() }) );
 			$element.remove();
-		});
+		} );
 
 		/**
 		 * Click handler for plugin updates in List Table view.
@@ -1153,13 +1154,13 @@ window.wp = window.wp || {};
 
 			if ( ! itemsSelected.length ) {
 				event.preventDefault();
-				$( 'html, body' ).animate({ scrollTop: 0 });
+				$( 'html, body' ).animate( { scrollTop: 0 } );
 
 				return wp.updates.addAdminNotice({
 					id: 'no-items-selected',
 					className: 'notice-error is-dismissible',
 					message: wp.updates.l10n.noItemsSelected
-				});
+				} );
 			}
 
 			switch ( action ) {
@@ -1219,13 +1220,13 @@ window.wp = window.wp || {};
 
 			if ( ! itemsSelected.length ) {
 				event.preventDefault();
-				$( 'html, body' ).animate({ scrollTop: 0 });
+				$( 'html, body' ).animate( { scrollTop: 0 } );
 
 				return wp.updates.addAdminNotice({
 					id: 'no-items-selected',
 					className: 'notice-error is-dismissible',
 					message: wp.updates.l10n.noItemsSelected
-				});
+				} );
 			}
 
 			switch ( action ) {
@@ -1296,7 +1297,7 @@ window.wp = window.wp || {};
  		 */
 		$document.on( 'wp-updates-notice-added wp-theme-update-error wp-theme-install-error', function() {
 			$( '.notice.is-dismissible' ).each( function() {
-				var $el = $( this ),
+				var $notice = $( this ),
 					$button = $( '<button type="button" class="notice-dismiss"><span class="screen-reader-text"></span></button>' ),
 					btnText = window.commonL10n.dismiss || '';
 
@@ -1304,14 +1305,15 @@ window.wp = window.wp || {};
 				$button.find( '.screen-reader-text' ).text( btnText );
 				$button.on( 'click.wp-dismiss-notice', function( event ) {
 					event.preventDefault();
-					$el.fadeTo( 100, 0, function() {
-						$el.slideUp( 100, function() {
-							$el.remove();
+
+					$notice.fadeTo( 100, 0, function() {
+						$notice.slideUp( 100, function() {
+							$notice.remove();
 						} );
 					} );
 				} );
 
-				$el.append( $button );
+				$notice.append( $button );
 			} );
 		} );
 
@@ -1338,7 +1340,7 @@ window.wp = window.wp || {};
 			wp.updates.searchRequest = wp.ajax.post( 'search-install-plugins', data ).done( function( response ) {
 				$theList.empty().append( response.items );
 				delete wp.updates.searchRequest;
-			});
+			} );
 		}, 250 ) );
 
 		/**
@@ -1375,7 +1377,7 @@ window.wp = window.wp || {};
 
 				$( '#bulk-action-form' ).empty().append( response.items );
 				delete wp.updates.searchRequest;
-			});
+			} );
 		}, 250 ) );
 
 		/**
@@ -1385,7 +1387,7 @@ window.wp = window.wp || {};
 		 */
 		$( '#typeselector' ).on( 'change', function() {
 			$( 'input.wp-filter-search' ).trigger( 'search' );
-		});
+		} );
 	} );
 
 	/**
@@ -1417,7 +1419,7 @@ window.wp = window.wp || {};
 		};
 
 		target.postMessage( JSON.stringify( job ), window.location.origin );
-	});
+	} );
 
 	/**
 	 * Handles postMessage events.

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -981,7 +981,7 @@ window.wp = window.wp || {};
 		} );
 
 		/**
-		 * Close the request credentials modal when clicking the 'Cancel' button or outside of he modal.
+		 * Close the request credentials modal when clicking the 'Cancel' button or outside of the modal.
 		 *
 		 * @since 4.2.0
 		 */

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -49,7 +49,7 @@ window.wp = window.wp || {};
 	 * @type {string} filesystemCredentials.ftp.host           FTP host. Default empty string.
 	 * @type {string} filesystemCredentials.ftp.username       FTP user name. Default empty string.
 	 * @type {string} filesystemCredentials.ftp.password       FTP password. Default empty string.
-	 * @type {string} filesystemCredentials.ftp.connectionType Type of FTP connection. 'ftp' or 'ftps'.
+	 * @type {string} filesystemCredentials.ftp.connectionType Type of FTP connection. 'ssh', 'ftp', or 'ftps'.
 	 *                                                         Default empty string.
 	 * @type {object} filesystemCredentials.ssh                Holds SSH credentials.
 	 * @type {string} filesystemCredentials.ssh.publicKey      The public key. Default empty string.
@@ -367,6 +367,8 @@ window.wp = window.wp || {};
 	 * Send an Ajax request to the server to update plugins in bulk.
 	 *
 	 * @since 4.X.0
+	 *
+	 * @param {array} plugins
 	 */
 	wp.updates.bulkUpdatePlugins = function( plugins ) {
 		var $message;

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -4,6 +4,11 @@ window.wp = window.wp || {};
 (function( $, wp ) {
 	var $document = $( document );
 
+	/**
+	 * The WP Updates object.
+	 *
+	 * @type {object}
+	 */
 	wp.updates = {};
 
 	/**
@@ -11,7 +16,7 @@ window.wp = window.wp || {};
 	 *
 	 * @since 4.2.0
 	 *
-	 * @var string
+	 * @type {string}
 	 */
 	wp.updates.ajaxNonce = window._wpUpdatesSettings.ajax_nonce;
 
@@ -20,7 +25,7 @@ window.wp = window.wp || {};
 	 *
 	 * @since 4.2.0
 	 *
-	 * @var object
+	 * @type {object}
 	 */
 	wp.updates.l10n = window._wpUpdatesSettings.l10n;
 
@@ -29,27 +34,39 @@ window.wp = window.wp || {};
 	 *
 	 * @since 4.2.0
 	 *
-	 * @var bool
+	 * @type {bool}
 	 */
-	wp.updates.shouldRequestFilesystemCredentials = null;
+	wp.updates.shouldRequestFilesystemCredentials = false;
 
 	/**
 	 * Filesystem credentials to be packaged along with the request.
 	 *
 	 * @since 4.2.0
+	 * @since 4.X.0 Added `available` property to indicate whether credentials have been provided.
 	 *
-	 * @var object
+	 * @type {object} filesystemCredentials                    Holds filesystem credentials.
+	 * @type {object} filesystemCredentials.ftp                Holds FTP credentials.
+	 * @type {string} filesystemCredentials.ftp.host           FTP host. Default empty string.
+	 * @type {string} filesystemCredentials.ftp.username       FTP user name. Default empty string.
+	 * @type {string} filesystemCredentials.ftp.password       FTP password. Default empty string.
+	 * @type {string} filesystemCredentials.ftp.connectionType Type of FTP connection. 'ftp' or 'ftps'.
+	 *                                                         Default empty string.
+	 * @type {object} filesystemCredentials.ssh                Holds SSH credentials.
+	 * @type {string} filesystemCredentials.ssh.publicKey      The public key. Default empty string.
+	 * @type {string} filesystemCredentials.ssh.privateKey     The private key. Default empty string.
+	 * @type {bool}   filesystemCredentials.available          Whether filesystem credentials have been provided.
+	 *                                                         Default 'false'.
 	 */
 	wp.updates.filesystemCredentials = {
 		ftp: {
-			host: null,
-			username: null,
-			password: null,
-			connectionType: null
+			host: '',
+			username: '',
+			password: '',
+			connectionType: ''
 		},
 		ssh: {
-			publicKey: null,
-			privateKey: null
+			publicKey: '',
+			privateKey: ''
 		},
 		available: false
 	};
@@ -59,7 +76,7 @@ window.wp = window.wp || {};
 	 *
 	 * @since 4.2.0
 	 *
-	 * @var bool
+	 * @type {bool}
 	 */
 	wp.updates.updateLock = false;
 
@@ -68,7 +85,7 @@ window.wp = window.wp || {};
 	 *
 	 * @since 4.X.0
 	 *
-	 * @var {function} A function that lazily-compiles the template requested.
+	 * @type {function} A function that lazily-compiles the template requested.
 	 */
 	wp.updates.adminNotice = wp.template( 'wp-updates-admin-notice' );
 
@@ -78,7 +95,7 @@ window.wp = window.wp || {};
 	 *
 	 * @since 4.2.0
 	 *
-	 * @var array
+	 * @type {array}
 	 */
 	wp.updates.updateQueue = [];
 
@@ -87,9 +104,9 @@ window.wp = window.wp || {};
 	 *
 	 * @since 4.2.0
 	 *
-	 * @var jQuery object
+	 * @type {jQuery}
 	 */
-	wp.updates.$elToReturnFocusToFromCredentialsModal = null;
+	wp.updates.$elToReturnFocusToFromCredentialsModal;
 
 	/**
 	 * Adds or updates an admin notice.

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -1040,14 +1040,6 @@ window.wp = window.wp || {};
 			$( this ).parents( 'form' ).find( '#private_key, #public_key' ).parents( 'label' ).toggle( ( 'ssh' === $( this ).val() ) );
 		}).change();
 
-		$( '.plugin-update-tr' ).each( function( index, element ) {
-			var $element   = $( element ),
-				$pluginRow = $element.prev();
-
-			$pluginRow.find( '.column-description' ).prepend( wp.updates.adminNotice({ className: 'update-message notice-warning notice-alt', message: $element.find( '.update-message p' ).html() }) );
-			$element.remove();
-		} );
-
 		/**
 		 * Click handler for plugin updates in List Table view.
 		 *
@@ -1124,7 +1116,7 @@ window.wp = window.wp || {};
 		 * @param {Event} event Event interface.
 		 */
 		$theList.on( 'click', '[data-plugin] a.delete', function( event ) {
-			var $link = $( event.target );
+			var $pluginRow = $( event.target ).parents( 'tr' );
 			event.preventDefault();
 
 			if ( ! window.confirm( wp.updates.l10n.aysDelete ) ) {
@@ -1135,7 +1127,7 @@ window.wp = window.wp || {};
 				wp.updates.requestFilesystemCredentials( event );
 			}
 
-			wp.updates.deletePlugin( $link.data( 'plugin' ), $link.data( 'slug' ) );
+			wp.updates.deletePlugin( $pluginRow.data( 'plugin' ), $pluginRow.data( 'slug' ) );
 		} );
 
 		/**

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -364,28 +364,6 @@ window.wp = window.wp || {};
 	};
 
 	/**
-	 * Send an Ajax request to the server to update plugins in bulk.
-	 *
-	 * @since 4.X.0
-	 *
-	 * @param {array} plugins
-	 */
-	wp.updates.bulkUpdatePlugins = function( plugins ) {
-		var $message;
-
-		_.each( plugins, function( plugin ) {
-			$message = $( 'tr[data-plugin="' + plugin.plugin + '"]' ).find( '.update-message' ).addClass( 'updating-message' ).find( 'p' );
-
-			if ( $message.html() !== wp.updates.l10n.updating ) {
-				$message.data( 'originaltext', $message.html() );
-			}
-			$message.text( wp.updates.l10n.updateQueued );
-
-			wp.updates.updatePlugin( plugin.plugin, plugin.slug );
-		} );
-	};
-
-	/**
 	 * Send an Ajax request to the server to install a plugin.
 	 *
 	 * @since 4.X.0

--- a/src/update.php
+++ b/src/update.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Changes to wp-admin/includes/update.php
+ *
+ * Only wp_plugin_update_row() and wp_theme_update_row() need to be changed.
+ *
+ * @package Shiny_Updates
+ */
+
+/**
+ * Replace update row functions with our own.
+ */
+function su_new_update_rows() {
+	remove_action( 'admin_init', 'wp_plugin_update_rows' );
+	remove_action( 'admin_init', 'wp_theme_update_rows' );
+	add_action( 'admin_init', 'su_plugin_update_rows' );
+	add_action( 'admin_init', 'su_theme_update_rows' );
+}
+add_action( 'admin_init', 'su_new_update_rows', 1 );
+
+/**
+ * Register plugin update rows.
+ *
+ * @since 2.9.0
+ */
+function su_plugin_update_rows() {
+	if ( ! current_user_can( 'update_plugins' ) ) {
+		return;
+	}
+
+	$plugins = get_site_transient( 'update_plugins' );
+	if ( isset( $plugins->response ) && is_array( $plugins->response ) ) {
+		$plugins = array_keys( $plugins->response );
+		foreach ( $plugins as $plugin_file ) {
+			add_action( "after_plugin_row_$plugin_file", 'su_plugin_update_row', 10, 2 );
+		}
+	}
+}
+
+/**
+ * Register theme update rows.
+ *
+ * @since 3.1.0
+ */
+function su_theme_update_rows() {
+	if ( ! current_user_can( 'update_themes' ) ) {
+		return;
+	}
+
+	$themes = get_site_transient( 'update_themes' );
+	if ( isset( $themes->response ) && is_array( $themes->response ) ) {
+		$themes = array_keys( $themes->response );
+
+		foreach ( $themes as $theme ) {
+			add_action( "after_theme_row_$theme", 'su_theme_update_row', 10, 2 );
+		}
+	}
+}
+
+/**
+ * Displays update information for a plugin.
+ *
+ * @param string $file        Plugin basename.
+ * @param array  $plugin_data Plugin information.
+ *
+ * @return false|void
+ */
+function su_plugin_update_row( $file, $plugin_data ) {
+	$current = get_site_transient( 'update_plugins' );
+	if ( ! isset( $current->response[ $file ] ) ) {
+		return false;
+	}
+
+	$r = $current->response[ $file ];
+
+	$plugins_allowedtags = array(
+		'a'       => array( 'href' => array(), 'title' => array() ),
+		'abbr'    => array( 'title' => array() ),
+		'acronym' => array( 'title' => array() ),
+		'code'    => array(),
+		'em'      => array(),
+		'strong'  => array(),
+	);
+
+	$plugin_name   = wp_kses( $plugin_data['Name'], $plugins_allowedtags );
+	$details_url   = self_admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $r->slug . '&section=changelog&TB_iframe=true&width=600&height=800' );
+	$wp_list_table = _get_list_table( 'WP_Plugins_List_Table' );
+
+	if ( is_network_admin() || ! is_multisite() ) {
+		if ( is_network_admin() ) {
+			$active_class = is_plugin_active_for_network( $file ) ? ' active' : '';
+		} else {
+			$active_class = is_plugin_active( $file ) ? ' active' : '';
+		}
+
+		echo '<tr class="plugin-update-tr' . $active_class . '" id="' . esc_attr( $r->slug . '-update' ) . '" data-slug="' . esc_attr( $r->slug ) . '" data-plugin="' . esc_attr( $file ) . '"><td colspan="' . esc_attr( $wp_list_table->get_column_count() ) . '" class="plugin-update colspanchange"><div class="update-message"><p>';
+
+		if ( ! current_user_can( 'update_plugins' ) ) {
+			/* translators: 1: plugin name, 2: details URL, 3: escaped plugin name, 4: version number */
+			printf( __( 'There is a new version of %1$s available. <a href="%2$s" class="thickbox" aria-label="View %3$s version %4$s details">View version %4$s details</a>.' ),
+				$plugin_name,
+				esc_url( $details_url ),
+				esc_attr( $plugin_name ),
+				$r->new_version
+			);
+		} elseif ( empty( $r->package ) ) {
+			/* translators: 1: plugin name, 2: details URL, 3: escaped plugin name, 4: version number */
+			printf( __( 'There is a new version of %1$s available. <a href="%2$s" class="thickbox" aria-label="View %3$s version %4$s details">View version %4$s details</a>. <em>Automatic update is unavailable for this plugin.</em>' ),
+				$plugin_name,
+				esc_url( $details_url ),
+				esc_attr( $plugin_name ),
+				$r->new_version
+			);
+		} else {
+			/* translators: 1: plugin name, 2: details URL, 3: escaped plugin name, 4: version number, 5: update URL */
+			printf( __( 'There is a new version of %1$s available. <a href="%2$s" class="thickbox" aria-label="View %3$s version %4$s details">View version %4$s details</a> or <a href="%5$s" class="update-link" aria-label="update %3$s now">update now</a>.' ),
+				$plugin_name,
+				esc_url( $details_url ),
+				esc_attr( $plugin_name ),
+				$r->new_version,
+				wp_nonce_url( self_admin_url( 'update.php?action=upgrade-plugin&plugin=' ) . $file, 'upgrade-plugin_' . $file )
+			);
+		}
+
+		/**
+		 * Fires at the end of the update message container in each
+		 * row of the plugins list table.
+		 *
+		 * The dynamic portion of the hook name, `$file`, refers to the path
+		 * of the plugin's primary file relative to the plugins directory.
+		 *
+		 * @since 2.8.0
+		 *
+		 * @param array $plugin_data {
+		 *                           An array of plugin metadata.
+		 *
+		 * @type string $name        The human-readable name of the plugin.
+		 * @type string $plugin_uri  Plugin URI.
+		 * @type string $version     Plugin version.
+		 * @type string $description Plugin description.
+		 * @type string $author      Plugin author.
+		 * @type string $author_uri  Plugin author URI.
+		 * @type string $text_domain Plugin text domain.
+		 * @type string $domain_path Relative path to the plugin's .mo file(s).
+		 * @type bool   $network     Whether the plugin can only be activated network wide.
+		 * @type string $title       The human-readable title of the plugin.
+		 * @type string $author_name Plugin author's name.
+		 * @type bool   $update      Whether there's an available update. Default null.
+		 * }
+		 *
+		 * @param array $r           {
+		 *                           An array of metadata about the available plugin update.
+		 *
+		 * @type int    $id          Plugin ID.
+		 * @type string $slug        Plugin slug.
+		 * @type string $new_version New plugin version.
+		 * @type string $url         Plugin URL.
+		 * @type string $package     Plugin update package URL.
+		 * }
+		 */
+		do_action( "in_plugin_update_message-{$file}", $plugin_data, $r );
+
+		echo '</p></div></td></tr>';
+	}
+}
+
+/**
+ * Displays update information for a theme.
+ *
+ * @param string   $theme_key Theme stylesheet.
+ * @param WP_Theme $theme     Theme object.
+ *
+ * @return false|void
+ */
+function su_theme_update_row( $theme_key, $theme ) {
+	$current = get_site_transient( 'update_themes' );
+	if ( ! isset( $current->response[ $theme_key ] ) ) {
+		return false;
+	}
+	$r = $current->response[ $theme_key ];
+
+	$details_url = add_query_arg( array(
+		'TB_iframe' => 'true',
+		'width'     => 1024,
+		'height'    => 800,
+	), $current->response[ $theme_key ]['url'] );
+
+	$wp_list_table = _get_list_table( 'WP_MS_Themes_List_Table' );
+
+	echo '<tr class="plugin-update-tr"><td colspan="' . $wp_list_table->get_column_count() . '" class="plugin-update colspanchange"><div class="update-message"><p>';
+	if ( ! current_user_can( 'update_themes' ) ) {
+		/* translators: 1: theme name, 2: details URL, 3: escaped theme name, 4: version number */
+		printf( __( 'There is a new version of %1$s available. <a href="%2$s" class="thickbox" aria-label="View %3$s version %4$s details">View version %4$s details</a>.' ),
+			$theme['Name'],
+			esc_url( $details_url ),
+			esc_attr( $theme['Name'] ),
+			$r->new_version
+		);
+	} elseif ( empty( $r['package'] ) ) {
+		/* translators: 1: theme name, 2: details URL, 3: escaped theme name, 4: version number */
+		printf( __( 'There is a new version of %1$s available. <a href="%2$s" class="thickbox" aria-label="View %3$s version %4$s details">View version %4$s details</a>. <em>Automatic update is unavailable for this theme.</em>' ),
+			$theme['Name'],
+			esc_url( $details_url ),
+			esc_attr( $theme['Name'] ),
+			$r['new_version']
+		);
+	} else {
+		/* translators: 1: theme name, 2: details URL, 3: escaped theme name, 4: version number, 5: update URL */
+		printf( __( 'There is a new version of %1$s available. <a href="%2$s" class="thickbox" aria-label="View %3$s version %4$s details">View version %4$s details</a> or <a href="%5$s" aria-label="update %3$s now">update now</a>.' ),
+			$theme['Name'],
+			esc_url( $details_url ),
+			esc_attr( $theme['Name'] ),
+			$r['new_version'],
+			wp_nonce_url( self_admin_url( 'update.php?action=upgrade-theme&theme=' ) . $theme_key, 'upgrade-theme_' . $theme_key )
+		);
+	}
+
+	/**
+	 * Fires at the end of the update message container in each
+	 * row of the themes list table.
+	 *
+	 * The dynamic portion of the hook name, `$theme_key`, refers to
+	 * the theme slug as found in the WordPress.org themes repository.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param WP_Theme $theme       The WP_Theme object.
+	 * @param array    $r           {
+	 *                              An array of metadata about the available theme update.
+	 *
+	 * @type string    $new_version New theme version.
+	 * @type string    $url         Theme URL.
+	 * @type string    $package     Theme update package URL.
+	 * }
+	 */
+	do_action( "in_theme_update_message-{$theme_key}", $theme, $r );
+
+	echo '</p></div></td></tr>';
+}

--- a/src/update.php
+++ b/src/update.php
@@ -93,7 +93,7 @@ function su_plugin_update_row( $file, $plugin_data ) {
 			$active_class = is_plugin_active( $file ) ? ' active' : '';
 		}
 
-		echo '<tr class="plugin-update-tr' . $active_class . '" id="' . esc_attr( $r->slug . '-update' ) . '" data-slug="' . esc_attr( $r->slug ) . '" data-plugin="' . esc_attr( $file ) . '"><td colspan="' . esc_attr( $wp_list_table->get_column_count() ) . '" class="plugin-update colspanchange"><div class="update-message"><p>';
+		echo '<tr class="plugin-update-tr' . $active_class . '" id="' . esc_attr( $r->slug . '-update' ) . '" data-slug="' . esc_attr( $r->slug ) . '" data-plugin="' . esc_attr( $file ) . '"><td colspan="' . esc_attr( $wp_list_table->get_column_count() ) . '" class="plugin-update colspanchange"><div class="update-message notice inline notice-warning notice-alt"><p>';
 
 		if ( ! current_user_can( 'update_plugins' ) ) {
 			/* translators: 1: plugin name, 2: details URL, 3: escaped plugin name, 4: version number */
@@ -187,7 +187,7 @@ function su_theme_update_row( $theme_key, $theme ) {
 
 	$wp_list_table = _get_list_table( 'WP_MS_Themes_List_Table' );
 
-	echo '<tr class="plugin-update-tr"><td colspan="' . $wp_list_table->get_column_count() . '" class="plugin-update colspanchange"><div class="update-message"><p>';
+	echo '<tr class="plugin-update-tr"><td colspan="' . $wp_list_table->get_column_count() . '" class="plugin-update colspanchange"><div class="update-message notice inline notice-warning notice-alt"><p>';
 	if ( ! current_user_can( 'update_themes' ) ) {
 		/* translators: 1: theme name, 2: details URL, 3: escaped theme name, 4: version number */
 		printf( __( 'There is a new version of %1$s available. <a href="%2$s" class="thickbox" aria-label="View %3$s version %4$s details">View version %4$s details</a>.' ),


### PR DESCRIPTION
* Correctly handles erroneous filesystem credentials when deleting
plugins or themes.
* Removes 4.5.0 version in favor of 4.X.0.
* Reworks update notifications to just be an admin notice.
* Reworked the way theme deletions are handled. It now doesn’t require
an extra page load anymore.
* Removes `wp.updates.updateDoneSuccessfully` to determine whether
filesystem credentials are available and uses an internal flag instead.
* Removes progress indicator for now.
* Now handles errors that occur when deleting plugins/themes. See #38.

WIP, more to come.