### PR TITLE
Set shiny-updates script as dependency.

### DIFF
--- a/src/class-shiny-updates.php
+++ b/src/class-shiny-updates.php
@@ -185,7 +185,7 @@ class Shiny_Updates {
 		) );
 
 		if ( 'theme-install.php' === $hook || ( 'themes.php' === $hook && ! is_network_admin() ) ) {
-			wp_enqueue_script( 'shiny-theme-updates', plugin_dir_url( __FILE__ ) . 'js/shiny-theme-updates.js', array( 'theme', 'updates' ), null, true );
+			wp_enqueue_script( 'shiny-theme-updates', plugin_dir_url( __FILE__ ) . 'js/shiny-theme-updates.js', array( 'theme', 'shiny-updates' ), null, true );
 		}
 
 		if ( 'theme-install.php' === $hook ) {


### PR DESCRIPTION
Ensures that all necessary dependencies are loaded in the and avoids
unnecessarily loading `updates.js`.