### PR TITLE
The readme.txt specifies a non-exitent stable tag

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,6 @@ Contributors: obenland, adamsilverstein, michaelarestad, mapk, j-falk, kraftbj, 
 Tags: updates, admin, feature-plugin, plugin, theme, multisite, network, auto-updates
 Requires at least: 4.4
 Tested up to: 4.5
-Stable tag: 2
 License: GPLv2 or later
 
 A smoother experience for managing plugins and themes.


### PR DESCRIPTION
The `Stable Tag` field is designed to point to a `/tags/x.y.z` directory, `/tags/2` does not exist in shiny-updates, so we should instead have this set to 'trunk' or omit it entirely.