### PR TITLE
Don't offer automatic updates if WP knows they're disabled

### DIFF
--- a/src/auto-updates.php
+++ b/src/auto-updates.php
@@ -11,23 +11,31 @@
 function shiny_auto_updates() {
 	add_settings_section( 'shiny_auto_updates', __( 'Automatic Updates' ), 'shiny_auto_updates_description', 'shiny_auto_updates' );
 
-	add_settings_field( 'shiny_wordpress_auto_updates', __( 'WordPress' ), 'shiny_auto_updates_checkbox_field', 'shiny_auto_updates', 'shiny_auto_updates', array(
-		'label_for'   => 'wp_auto_update_core',
-		'label'       => __( 'Update WordPress automatically.' ),
-		'description' => __( 'Minor versions of WordPress are automatically updated by default.' ),
-	) );
-	add_settings_field( 'shiny_plugin_auto_updates', __( 'Plugins' ), 'shiny_auto_updates_checkbox_field', 'shiny_auto_updates', 'shiny_auto_updates', array(
-		'label_for' => 'wp_auto_update_plugins',
-		'label'     => __( 'Update plugins automatically.' ),
-	) );
-	add_settings_field( 'shiny_theme_auto_updates', __( 'Themes' ), 'shiny_auto_updates_checkbox_field', 'shiny_auto_updates', 'shiny_auto_updates', array(
-		'label_for' => 'wp_auto_update_themes',
-		'label'     => __( 'Update themes automatically.' ),
-	) );
+	if ( ! class_exists( 'WP_Automatic_Updater' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+	}
 
-	add_filter( 'sanitize_option_wp_auto_update_core',    'absint' );
-	add_filter( 'sanitize_option_wp_auto_update_plugins', 'absint' );
-	add_filter( 'sanitize_option_wp_auto_update_themes',  'absint' );
+	$updater = new WP_Automatic_Updater;
+
+	if ( ! $updater->is_disabled() ) {
+		add_settings_field( 'shiny_wordpress_auto_updates', __( 'WordPress' ), 'shiny_auto_updates_checkbox_field', 'shiny_auto_updates', 'shiny_auto_updates', array(
+			'label_for'   => 'wp_auto_update_core',
+			'label'       => __( 'Update WordPress automatically.' ),
+			'description' => __( 'Minor versions of WordPress are automatically updated by default.' ),
+		) );
+		add_settings_field( 'shiny_plugin_auto_updates', __( 'Plugins' ), 'shiny_auto_updates_checkbox_field', 'shiny_auto_updates', 'shiny_auto_updates', array(
+			'label_for' => 'wp_auto_update_plugins',
+			'label'     => __( 'Update plugins automatically.' ),
+		) );
+		add_settings_field( 'shiny_theme_auto_updates', __( 'Themes' ), 'shiny_auto_updates_checkbox_field', 'shiny_auto_updates', 'shiny_auto_updates', array(
+			'label_for' => 'wp_auto_update_themes',
+			'label'     => __( 'Update themes automatically.' ),
+		) );
+
+		add_filter( 'sanitize_option_wp_auto_update_core', 'absint' );
+		add_filter( 'sanitize_option_wp_auto_update_plugins', 'absint' );
+		add_filter( 'sanitize_option_wp_auto_update_themes', 'absint' );
+	}
 }
 add_action( 'load-update-core.php', 'shiny_auto_updates' );
 
@@ -87,12 +95,22 @@ function shiny_auto_updates_checkbox_field( $args ) {
  * Renders the auto update settings.
  */
 function shiny_auto_updates_render() {
-	$action = is_network_admin() ? 'update-core.php?action=auto-updates' : 'options.php';
-	printf( '<form method="post" action="%s">', esc_url( $action ) );
+	$updater = new WP_Automatic_Updater;
+
+	if ( $updater->is_disabled() ) {
+		do_settings_sections( 'shiny_auto_updates' );
+
+		?>
+		<p><?php esc_html_e( 'Due to your site&#8217;s configuration, automattic updates are not available.' ); ?></p>
+		<?php
+	} else {
+		$action = is_network_admin() ? 'update-core.php?action=auto-updates' : 'options.php';
+		printf( '<form method="post" action="%s">', esc_url( $action ) );
 		settings_fields( 'shiny_auto_updates' );
 		do_settings_sections( 'shiny_auto_updates' );
 		submit_button();
-	echo '</form>';
+		echo '</form>';
+	}
 }
 add_action( 'core_upgrade_preamble', 'shiny_auto_updates_render' );
 


### PR DESCRIPTION
If Core determines that automatic updates aren't possible, options shouldn't be offered to enable them.