### PR TITLE
Display check mark after installing

### DIFF
--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -84,7 +84,7 @@
 	-moz-osx-font-smoothing: grayscale;
 	speak: none;
 	margin: 0 8px 0 -2px;
-	vertical-align: top;
+	vertical-align: text-top;
 }
 
 /* Inline notifications */

--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -13,7 +13,7 @@
 .plugin-card .update-now:before,
 .plugin-card .install-now:before,
 .theme .update-message:before {
-	color: #ffb900;
+	color: #f56e28;
 	content: "\f463";
 }
 
@@ -36,7 +36,7 @@
 
 .theme-info .updating-message:before,
 .theme-install.updating-message:before {
-	color: #ffb900;
+	color: #f56e28;
 	content: "\f463";
 	-webkit-animation: rotation 2s infinite linear;
 	animation: rotation 2s infinite linear;
@@ -64,7 +64,7 @@
 .button.installing::before {
 	-webkit-animation: rotation 2s infinite linear;
 	animation: rotation 2s infinite linear;
-	color: #ffb900;
+	color: #f56e28;
 	content: '\f463';
 	display: inline-block;
 	font: normal 20px/1 'dashicons';
@@ -119,7 +119,7 @@ tr.active.update + tr.plugin-update-tr .plugin-update {
 }
 
 .update-message p:before {
-	color: #ffb900;
+	color: #f56e28;
 	display: inline-block;
 	font: normal 20px/1 dashicons;
 	content: "\f463";

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -399,7 +399,7 @@ window.wp = window.wp || {};
 	wp.updates.installPluginSuccess = function( response ) {
 		var $message = $( '.plugin-card-' + response.slug ).find( '.install-now' );
 
-		$message.removeClass( 'updating-message' ).addClass( 'updated-message button-disabled' );
+		$message.removeClass( 'updating-message' ).addClass( 'installed updated-message button-disabled' );
 		$message.text( wp.updates.l10n.installed );
 		wp.a11y.speak( wp.updates.l10n.installedMsg, 'polite' );
 


### PR DESCRIPTION
Fixes a bug where the update/install arrows were displayed after a
plugin had finished installing.