### PR TITLE
Allow plugin installations from Details modal

### DIFF
--- a/src/class-shiny-updates.php
+++ b/src/class-shiny-updates.php
@@ -61,6 +61,9 @@ class Shiny_Updates {
 		// Delete Themes.
 		add_action( 'wp_ajax_delete-theme', 'wp_ajax_delete_theme' );
 
+		// Plugin modal installations.
+		add_action( 'install_plugins_pre_plugin-information', array( $this, 'install_plugin_information' ), 9 );
+
 		// Auto Updates.
 		add_action( 'admin_init', array( $this, 'load_auto_updates_settings' ) );
 
@@ -346,6 +349,263 @@ class Shiny_Updates {
 			</div>
 		</script>
 	<?php
+	}
+
+	/**
+	 * Redefine `install_plugin_information()` to add an id and data attribute to the install button.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @global string $tab
+	 * @global string $wp_version
+	 */
+	public function install_plugin_information() {
+		// @codingStandardsIgnoreStart
+		global $tab;
+
+		remove_action( 'install_plugins_pre_plugin-information', 'install_plugin_information' );
+
+		if ( empty( $_REQUEST['plugin'] ) ) {
+			return;
+		}
+
+		$api = plugins_api( 'plugin_information', array(
+			'slug' => wp_unslash( $_REQUEST['plugin'] ),
+			'is_ssl' => is_ssl(),
+			'fields' => array(
+				'banners' => true,
+				'reviews' => true,
+				'downloaded' => false,
+				'active_installs' => true
+			)
+		) );
+
+		if ( is_wp_error( $api ) ) {
+			wp_die( $api );
+		}
+
+		$plugins_allowedtags = array(
+			'a' => array( 'href' => array(), 'title' => array(), 'target' => array() ),
+			'abbr' => array( 'title' => array() ), 'acronym' => array( 'title' => array() ),
+			'code' => array(), 'pre' => array(), 'em' => array(), 'strong' => array(),
+			'div' => array( 'class' => array() ), 'span' => array( 'class' => array() ),
+			'p' => array(), 'ul' => array(), 'ol' => array(), 'li' => array(),
+			'h1' => array(), 'h2' => array(), 'h3' => array(), 'h4' => array(), 'h5' => array(), 'h6' => array(),
+			'img' => array( 'src' => array(), 'class' => array(), 'alt' => array() )
+		);
+
+		$plugins_section_titles = array(
+			'description'  => _x( 'Description',  'Plugin installer section title' ),
+			'installation' => _x( 'Installation', 'Plugin installer section title' ),
+			'faq'          => _x( 'FAQ',          'Plugin installer section title' ),
+			'screenshots'  => _x( 'Screenshots',  'Plugin installer section title' ),
+			'changelog'    => _x( 'Changelog',    'Plugin installer section title' ),
+			'reviews'      => _x( 'Reviews',      'Plugin installer section title' ),
+			'other_notes'  => _x( 'Other Notes',  'Plugin installer section title' )
+		);
+
+		// Sanitize HTML
+		foreach ( (array) $api->sections as $section_name => $content ) {
+			$api->sections[$section_name] = wp_kses( $content, $plugins_allowedtags );
+		}
+
+		foreach ( array( 'version', 'author', 'requires', 'tested', 'homepage', 'downloaded', 'slug' ) as $key ) {
+			if ( isset( $api->$key ) ) {
+				$api->$key = wp_kses( $api->$key, $plugins_allowedtags );
+			}
+		}
+
+		$_tab = esc_attr( $tab );
+
+		$section = isset( $_REQUEST['section'] ) ? wp_unslash( $_REQUEST['section'] ) : 'description'; // Default to the Description tab, Do not translate, API returns English.
+		if ( empty( $section ) || ! isset( $api->sections[ $section ] ) ) {
+			$section_titles = array_keys( (array) $api->sections );
+			$section = reset( $section_titles );
+		}
+
+		iframe_header( __( 'Plugin Install' ) );
+
+		$_with_banner = '';
+
+		if ( ! empty( $api->banners ) && ( ! empty( $api->banners['low'] ) || ! empty( $api->banners['high'] ) ) ) {
+			$_with_banner = 'with-banner';
+			$low  = empty( $api->banners['low'] ) ? $api->banners['high'] : $api->banners['low'];
+			$high = empty( $api->banners['high'] ) ? $api->banners['low'] : $api->banners['high'];
+			?>
+			<style type="text/css">
+				#plugin-information-title.with-banner {
+					background-image: url( <?php echo esc_url( $low ); ?> );
+				}
+				@media only screen and ( -webkit-min-device-pixel-ratio: 1.5 ) {
+					#plugin-information-title.with-banner {
+						background-image: url( <?php echo esc_url( $high ); ?> );
+					}
+				}
+			</style>
+		<?php
+		}
+
+		echo '<div id="plugin-information-scrollable">';
+		echo "<div id='{$_tab}-title' class='{$_with_banner}'><div class='vignette'></div><h2>{$api->name}</h2></div>";
+		echo "<div id='{$_tab}-tabs' class='{$_with_banner}'>\n";
+
+		foreach ( (array) $api->sections as $section_name => $content ) {
+			if ( 'reviews' === $section_name && ( empty( $api->ratings ) || 0 === array_sum( (array) $api->ratings ) ) ) {
+				continue;
+			}
+
+			if ( isset( $plugins_section_titles[ $section_name ] ) ) {
+				$title = $plugins_section_titles[ $section_name ];
+			} else {
+				$title = ucwords( str_replace( '_', ' ', $section_name ) );
+			}
+
+			$class = ( $section_name === $section ) ? ' class="current"' : '';
+			$href = add_query_arg( array('tab' => $tab, 'section' => $section_name) );
+			$href = esc_url( $href );
+			$san_section = esc_attr( $section_name );
+			echo "\t<a name='$san_section' href='$href' $class>$title</a>\n";
+		}
+
+		echo "</div>\n";
+
+		?>
+	<div id="<?php echo $_tab; ?>-content" class='<?php echo $_with_banner; ?>'>
+		<div class="fyi">
+			<ul>
+				<?php if ( ! empty( $api->version ) ) { ?>
+					<li><strong><?php _e( 'Version:' ); ?></strong> <?php echo $api->version; ?></li>
+				<?php } if ( ! empty( $api->author ) ) { ?>
+					<li><strong><?php _e( 'Author:' ); ?></strong> <?php echo links_add_target( $api->author, '_blank' ); ?></li>
+				<?php } if ( ! empty( $api->last_updated ) ) { ?>
+					<li><strong><?php _e( 'Last Updated:' ); ?></strong>
+						<?php printf( __( '%s ago' ), human_time_diff( strtotime( $api->last_updated ) ) ); ?>
+					</li>
+				<?php } if ( ! empty( $api->requires ) ) { ?>
+					<li><strong><?php _e( 'Requires WordPress Version:' ); ?></strong> <?php printf( __( '%s or higher' ), $api->requires ); ?></li>
+				<?php } if ( ! empty( $api->tested ) ) { ?>
+					<li><strong><?php _e( 'Compatible up to:' ); ?></strong> <?php echo $api->tested; ?></li>
+				<?php } if ( ! empty( $api->active_installs ) ) { ?>
+					<li><strong><?php _e( 'Active Installs:' ); ?></strong> <?php
+						if ( $api->active_installs >= 1000000 ) {
+							_ex( '1+ Million', 'Active plugin installs' );
+						} else {
+							echo number_format_i18n( $api->active_installs ) . '+';
+						}
+						?></li>
+				<?php } if ( ! empty( $api->slug ) && empty( $api->external ) ) { ?>
+					<li><a target="_blank" href="https://wordpress.org/plugins/<?php echo $api->slug; ?>/"><?php _e( 'WordPress.org Plugin Page &#187;' ); ?></a></li>
+				<?php } if ( ! empty( $api->homepage ) ) { ?>
+					<li><a target="_blank" href="<?php echo esc_url( $api->homepage ); ?>"><?php _e( 'Plugin Homepage &#187;' ); ?></a></li>
+				<?php } if ( ! empty( $api->donate_link ) && empty( $api->contributors ) ) { ?>
+					<li><a target="_blank" href="<?php echo esc_url( $api->donate_link ); ?>"><?php _e( 'Donate to this plugin &#187;' ); ?></a></li>
+				<?php } ?>
+			</ul>
+			<?php if ( ! empty( $api->rating ) ) { ?>
+				<h3><?php _e( 'Average Rating' ); ?></h3>
+				<?php wp_star_rating( array( 'rating' => $api->rating, 'type' => 'percent', 'number' => $api->num_ratings ) ); ?>
+				<p aria-hidden="true" class="fyi-description"><?php printf( _n( '(based on %s rating)', '(based on %s ratings)', $api->num_ratings ), number_format_i18n( $api->num_ratings ) ); ?></p>
+			<?php }
+
+			if ( ! empty( $api->ratings ) && array_sum( (array) $api->ratings ) > 0 ) { ?>
+				<h3><?php _e( 'Reviews' ); ?></h3>
+				<p class="fyi-description"><?php _e( 'Read all reviews on WordPress.org or write your own!' ); ?></p>
+				<?php
+				foreach ( $api->ratings as $key => $ratecount ) {
+					// Avoid div-by-zero.
+					$_rating = $api->num_ratings ? ( $ratecount / $api->num_ratings ) : 0;
+					/* translators: 1: number of stars (used to determine singular/plural), 2: number of reviews */
+					$aria_label = esc_attr( sprintf( _n( 'Reviews with %1$d star: %2$s. Opens in a new window.', 'Reviews with %1$d stars: %2$s. Opens in a new window.', $key ),
+						$key,
+						number_format_i18n( $ratecount )
+					) );
+					?>
+					<div class="counter-container">
+						<span class="counter-label"><a href="https://wordpress.org/support/view/plugin-reviews/<?php echo $api->slug; ?>?filter=<?php echo $key; ?>"
+						                               target="_blank" aria-label="<?php echo $aria_label; ?>"><?php printf( _n( '%d star', '%d stars', $key ), $key ); ?></a></span>
+						<span class="counter-back">
+							<span class="counter-bar" style="width: <?php echo 92 * $_rating; ?>px;"></span>
+						</span>
+						<span class="counter-count" aria-hidden="true"><?php echo number_format_i18n( $ratecount ); ?></span>
+					</div>
+				<?php
+				}
+			}
+			if ( ! empty( $api->contributors ) ) { ?>
+				<h3><?php _e( 'Contributors' ); ?></h3>
+				<ul class="contributors">
+					<?php
+					foreach ( (array) $api->contributors as $contrib_username => $contrib_profile ) {
+						if ( empty( $contrib_username ) && empty( $contrib_profile ) ) {
+							continue;
+						}
+						if ( empty( $contrib_username ) ) {
+							$contrib_username = preg_replace( '/^.+\/(.+)\/?$/', '\1', $contrib_profile );
+						}
+						$contrib_username = sanitize_user( $contrib_username );
+						if ( empty( $contrib_profile ) ) {
+							echo "<li><img src='https://wordpress.org/grav-redirect.php?user={$contrib_username}&amp;s=36' width='18' height='18' alt='' />{$contrib_username}</li>";
+						} else {
+							echo "<li><a href='{$contrib_profile}' target='_blank'><img src='https://wordpress.org/grav-redirect.php?user={$contrib_username}&amp;s=36' width='18' height='18' alt='' />{$contrib_username}</a></li>";
+						}
+					}
+					?>
+				</ul>
+				<?php if ( ! empty( $api->donate_link ) ) { ?>
+					<a target="_blank" href="<?php echo esc_url( $api->donate_link ); ?>"><?php _e( 'Donate to this plugin &#187;' ); ?></a>
+				<?php } ?>
+			<?php } ?>
+		</div>
+		<div id="section-holder" class="wrap">
+		<?php
+			if ( ! empty( $api->tested ) && version_compare( substr( $GLOBALS['wp_version'], 0, strlen( $api->tested ) ), $api->tested, '>' ) ) {
+				echo '<div class="notice notice-warning notice-alt"><p>' . __( '<strong>Warning:</strong> This plugin has <strong>not been tested</strong> with your current version of WordPress.' ) . '</p></div>';
+			} elseif ( ! empty( $api->requires ) && version_compare( substr( $GLOBALS['wp_version'], 0, strlen( $api->requires ) ), $api->requires, '<' ) ) {
+				echo '<div class="notice notice-warning notice-alt"><p>' . __( '<strong>Warning:</strong> This plugin has <strong>not been marked as compatible</strong> with your version of WordPress.' ) . '</p></div>';
+			}
+
+			foreach ( (array) $api->sections as $section_name => $content ) {
+				$content = links_add_base_url( $content, 'https://wordpress.org/plugins/' . $api->slug . '/' );
+				$content = links_add_target( $content, '_blank' );
+
+				$san_section = esc_attr( $section_name );
+
+				$display = ( $section_name === $section ) ? 'block' : 'none';
+
+				echo "\t<div id='section-{$san_section}' class='section' style='display: {$display};'>\n";
+				echo $content;
+				echo "\t</div>\n";
+			}
+		echo "</div>\n";
+		echo "</div>\n";
+		echo "</div>\n"; // #plugin-information-scrollable
+		echo "<div id='$tab-footer'>\n";
+		if ( ! empty( $api->download_link ) && ( current_user_can( 'install_plugins' ) || current_user_can( 'update_plugins' ) ) ) {
+			$status = install_plugin_install_status( $api );
+			switch ( $status['status'] ) {
+				case 'install':
+					if ( $status['url'] ) {
+						echo '<a data-slug="' . esc_attr( $api->slug ) . '" id="plugin_install_from_iframe" class="button button-primary right" href="' . $status['url'] . '" target="_parent">' . __( 'Install Now' ) . '</a>';
+					}
+					break;
+				case 'update_available':
+					if ( $status['url'] ) {
+						echo '<a data-slug="' . esc_attr( $api->slug ) . '" data-plugin="' . esc_attr( $status['file'] ) . '" id="plugin_update_from_iframe" class="button button-primary right" href="' . $status['url'] . '" target="_parent">' . __( 'Install Update Now' ) .'</a>';
+					}
+					break;
+				case 'newer_installed':
+					echo '<a class="button button-primary right disabled">' . sprintf( __( 'Newer Version (%s) Installed'), $status['version'] ) . '</a>';
+					break;
+				case 'latest_installed':
+					echo '<a class="button button-primary right disabled">' . __( 'Latest Version Installed' ) . '</a>';
+					break;
+			}
+		}
+		echo "</div>\n";
+
+		iframe_footer();
+		exit;
+		// @codingStandardsIgnoreEnd
 	}
 
 	/**

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -1530,6 +1530,36 @@ window.wp = window.wp || {};
 	} );
 
 	/**
+	 * Install plugin from the details modal on `plugin-install.php`.
+	 *
+	 * @since 4.X.0
+	 *
+	 * @param {Event} event Event interface.
+	 */
+	$( '#plugin_install_from_iframe' ).on( 'click', function( event ) {
+		var target = window.parent === window ? null : window.parent,
+			job;
+
+		$.support.postMessage = !! window.postMessage;
+
+		if ( false === $.support.postMessage || null === target || -1 !== window.parent.location.pathname.indexOf( 'update-core.php' ) ) {
+			return;
+		}
+
+		event.preventDefault();
+
+		job = {
+			action: 'installPlugin',
+			type: 'install-plugin',
+			data: {
+				slug: $( this ).data( 'slug' )
+			}
+		};
+
+		target.postMessage( JSON.stringify( job ), window.location.origin );
+	} );
+
+	/**
 	 * Handles postMessage events.
 	 *
 	 * @since 4.2.0
@@ -1562,6 +1592,7 @@ window.wp = window.wp || {};
 				break;
 
 			case 'updatePlugin':
+			case 'installPlugin':
 				/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 				window.tb_remove();
 				/* jscs:enable */


### PR DESCRIPTION
Brings installations en par with updates from plugins details modals.

Unfortunately it required to c/p the entire modal in order to add an id
and a data attribute to the Install Now button.