### PR TITLE
Unify updates/install success messages.

### DIFF
--- a/src/class-shiny-updates.php
+++ b/src/class-shiny-updates.php
@@ -288,7 +288,7 @@ class Shiny_Updates {
 			</div>
 
 			<# if ( data.installed ) { #>
-				<div class="theme-installed"><?php _ex( 'Already Installed', 'theme' ); ?></div>
+				<div class="notice notice-success notice-alt"><p><?php _ex( 'Installed', 'theme' ); ?></p></div>
 			<# } #>
 		</script>
 


### PR DESCRIPTION
Adjusts the installed-theme-message to visually fit in with the rest of
shiny updates messages

Fixes #95.