### PR TITLE
First pass at revamped update-core.php page

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# http://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[{.jshintrc,*.json,*.yml}]
+indent_style = space
+indent_size = 2
+
+[{*.txt,wp-config-sample.php}]
+end_of_line = crlf

--- a/.jshintrc
+++ b/.jshintrc
@@ -21,6 +21,7 @@
     "Backbone": false,
     "jQuery": false,
     "JSON": false,
+    "pagenow": false,
     "wp": false
   }
 }

--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -12,6 +12,7 @@
         <exclude name="WordPress.XSS.EscapeOutput.OutputNotEscaped" />
         <exclude name="WordPress.VIP.SuperGlobalInputUsage.AccessDetected" />
         <exclude name="WordPress.Variables.GlobalVariables.OverrideProhibited" />
+        <exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar" />
     </rule>
 
     <!-- Include sniffs for PHP cross-version compatibility. -->

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "license": "GPL-2.0+",
   "devDependencies": {
     "grunt": "~0.4.5",
-    "grunt-contrib-jshint": "~0.11.3",
-    "grunt-contrib-qunit": "~0.7.0",
-    "grunt-contrib-watch": "~0.6.1",
+    "grunt-contrib-jshint": "~1.0.0",
+    "grunt-contrib-qunit": "~1.1.0",
+    "grunt-contrib-watch": "~1.0.0",
     "grunt-jscs": "^2.5.0",
     "grunt-phpcs": "^0.4.0"
   }

--- a/src/ajax-actions.php
+++ b/src/ajax-actions.php
@@ -588,6 +588,15 @@ function wp_ajax_update_core() {
 		return;
 	}
 
+	$status = array(
+		'update'   => 'core',
+		'redirect' => esc_url( self_admin_url( 'about.php?updated' ) ),
+	);
+
+	if ( $update->current === $update->version ) {
+		wp_send_json_success( $status );
+	}
+
 	include_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
 
 	if ( $reinstall ) {
@@ -596,11 +605,6 @@ function wp_ajax_update_core() {
 
 	$upgrader = new WP_Automatic_Updater();
 	$result   = $upgrader->update( 'core', $update );
-
-	$status = array(
-		'update'   => 'core',
-		'redirect' => esc_url( self_admin_url( 'about.php?updated' ) ),
-	);
 
 	if ( is_array( $result ) && ! empty( $result[0] ) ) {
 		wp_send_json_success( $status );

--- a/src/ajax-actions.php
+++ b/src/ajax-actions.php
@@ -592,8 +592,8 @@ function wp_ajax_update_core() {
 
 	$reinstall = isset( $_POST['reinstall'] ) ? (bool) $_POST['reinstall'] : false;
 
-	$version = isset( $_POST['version'] ) ? $_POST['version'] : false;
-	$locale  = isset( $_POST['locale'] ) ? $_POST['locale'] : 'en_US';
+	$version = isset( $_POST['version'] ) ? wp_unslash( $_POST['version'] ) : false;
+	$locale  = isset( $_POST['locale'] ) ? wp_unslash( $_POST['locale'] ) : 'en_US';
 
 	$update = find_core_update( $version, $locale );
 

--- a/src/ajax-actions.php
+++ b/src/ajax-actions.php
@@ -625,7 +625,7 @@ function wp_ajax_update_core() {
 		$status['error'] = $result->get_error_message();
 		wp_send_json_error( $status );
 	} else if ( false === $result ) {
-		// These aren't actual errors
+		// These aren't actual errors.
 		$status['error'] = __( 'Installation Failed' );
 		wp_send_json_error( $status );
 	}

--- a/src/ajax-actions.php
+++ b/src/ajax-actions.php
@@ -502,3 +502,61 @@ function wp_ajax_search_install_plugins() {
 
 	wp_send_json_success( $status );
 }
+
+/**
+ * AJAX handler for updating a plugin.
+ *
+ * @since 4.6.0
+ *
+ * @see Language_Pack_Upgrader
+ */
+function wp_ajax_update_translations() {
+	check_ajax_referer( 'updates' );
+
+	if ( ! current_user_can( 'update_core' ) && ! current_user_can( 'update_plugins' ) && ! current_user_can( 'update_themes' ) ) {
+		$status['error'] = __( 'You do not have sufficient permissions to update this site.' );
+		wp_send_json_error( $status );
+	}
+
+	include_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
+
+	$url     = 'update-core.php?action=do-translation-upgrade';
+	$nonce   = 'upgrade-translations';
+	$title   = __( 'Update Translations' );
+	$context = WP_LANG_DIR;
+
+	$skin     = new Automatic_Upgrader_Skin( compact( 'url', 'nonce', 'title', 'context' ) );
+	$upgrader = new Language_Pack_Upgrader( $skin );
+	$result   = $upgrader->bulk_upgrade();
+
+	$status = array(
+		'update' => 'translation',
+	);
+
+	if ( is_array( $result ) && is_wp_error( $skin->result ) ) {
+		$result = $skin->result;
+	}
+
+	if ( is_array( $result ) && ! empty( $result[0] ) ) {
+		wp_send_json_success( $status );
+	} else if ( is_wp_error( $result ) ) {
+		$status['error'] = $result->get_error_message();
+		wp_send_json_error( $status );
+	} else if ( false === $result ) {
+		global $wp_filesystem;
+
+		$status['errorCode'] = 'unable_to_connect_to_filesystem';
+		$status['error']     = __( 'Unable to connect to the filesystem. Please confirm your credentials.' );
+
+		// Pass through the error from WP_Filesystem if one was raised.
+		if ( is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->get_error_code() ) {
+			$status['error'] = $wp_filesystem->errors->get_error_message();
+		}
+
+		wp_send_json_error( $status );
+	}
+
+	// An unhandled error occurred.
+	$status['error'] = __( 'Translations update failed.' );
+	wp_send_json_error( $status );
+}

--- a/src/ajax-actions.php
+++ b/src/ajax-actions.php
@@ -592,8 +592,8 @@ function wp_ajax_update_core() {
 
 	$reinstall = isset( $_POST['reinstall'] ) ? (bool) $_POST['reinstall'] : false;
 
-	$version = isset( $_POST['version'] ) ? wp_unslash( $_POST['version'] ) : false;
-	$locale  = isset( $_POST['locale'] ) ? wp_unslash( $_POST['locale'] ) : 'en_US';
+	$version = isset( $_POST['version'] ) ? sanitize_text_field( wp_unslash( $_POST['version'] ) ) : false;
+	$locale  = isset( $_POST['locale'] ) ? sanitize_text_field( wp_unslash( $_POST['locale'] ) ) : 'en_US';
 
 	$update = find_core_update( $version, $locale );
 

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -399,7 +399,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	 * @since  4.X.0
 	 * @access public
 	 *
-	 * @param object  $update     The current core update item.
+	 * @param object $update The current core update item.
 	 */
 	protected function _list_core_update( $update ) {
 		global $wp_version;
@@ -419,29 +419,22 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 			$current = true;
 		}
 
-		$form_action  = 'update-core.php?action=do-core-upgrade';
-		$show_buttons = true;
+		$form_action = 'update-core.php?action=do-core-upgrade';
 		if ( 'development' == $update->response ) {
-			$message  = __( 'You are using a development version of WordPress. You can update to the latest nightly build automatically or download the nightly build and install it manually:' );
-			$download = __( 'Download nightly build' );
+			$message = __( 'You are using a development version of WordPress. You can update to the latest nightly build automatically:' );
 		} else {
 			if ( $current ) {
-				$message     = sprintf( __( 'If you need to re-install version %s, you can do so here or download the package and re-install manually:' ), $version_string );
+				$message     = sprintf( __( 'If you need to re-install version %s, you can do so here:' ), $version_string );
 				$form_action = 'update-core.php?action=do-core-reinstall';
 			} else {
-				$message      = sprintf( __( 'You can update to <a href="https://codex.wordpress.org/Version_%1$s">WordPress %2$s</a> automatically or download the package and install it manually:' ), $update->current, $version_string );
-				$show_buttons = false;
+				$message = sprintf( __( 'You can update to <a href="https://codex.wordpress.org/Version_%1$s">WordPress %2$s</a> automatically:' ), $update->current, $version_string );
 			}
 
-			$download = sprintf( __( 'Download %s' ), $version_string );
 		}
 
 		echo '<p>';
 		echo $message;
 
-		if ( $show_buttons ) {
-			echo '&nbsp;<a href="' . esc_url( $update->download ) . '">' . $download . '</a>&nbsp;';
-		}
 		echo '</p>';
 
 		echo '<form method="post" action="' . $form_action . '" name="upgrade" class="upgrade">';

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -157,7 +157,10 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 		$data       = '';
 		$attributes = array( 'data-type' => $item['type'] );
 
-		if ( 'theme' === $item['type'] ) {
+		if ( 'core' === $item['type'] ) {
+			$attributes['data-version'] = esc_attr( $item['data'][0]->current );
+			$attributes['data-locale'] = esc_attr( $item['data'][0]->locale );
+		} else if ( 'theme' === $item['type'] ) {
 			$attributes['data-slug'] = $item['slug'];
 		} else if ( 'plugin' === $item['type'] ) {
 			$attributes['data-slug']   = $item['slug'];
@@ -377,7 +380,10 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 		?>
 		<form method="post" action="<?php echo esc_url( $form_action ); ?>" name="upgrade-all">
 			<?php wp_nonce_field( $nonce_action ); ?>
-			<?php if ( 'core' !== $item['type'] ) : ?>
+			<?php if ( 'core' === $item['type'] ) : ?>
+				<input name="version" value="<?php echo esc_attr( $item['data'][0]->current ); ?>" type="hidden"/>
+				<input name="locale" value="<?php echo esc_attr( $item['data'][0]->locale ); ?>" type="hidden"/>
+			<?php else: ?>
 				<input type="hidden" name="checked[]" id="<?php echo $checkbox_id; ?>" value="<?php echo esc_attr( $slug ); ?>"/>
 			<?php endif; ?>
 			<?php

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -129,6 +129,27 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Generates content for a single row of the table
+	 *
+	 * @access public
+	 *
+	 * @param object $item The current item.
+	 */
+	public function single_row( $item ) {
+		$data = '';
+
+		if ( 'theme' === $item['type'] ) {
+			$data = "data-slug='" . $item['slug'] . "'";
+		} else if ( 'plugin' === $item['type'] ) {
+			$data = "data-plugin='" . $item['slug'] . "'";
+		}
+
+		echo "<tr $data>";
+		$this->single_row_columns( $item );
+		echo '</tr>';
+	}
+
+	/**
 	 * Handles the title column output.
 	 *
 	 * @access public

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -163,8 +163,8 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 		} else if ( 'theme' === $item['type'] ) {
 			$attributes['data-slug'] = $item['slug'];
 		} else if ( 'plugin' === $item['type'] ) {
-			$attributes['data-slug']   = $item['slug'];
-			$attributes['data-plugin'] = $item['data']->update->slug;
+			$attributes['data-slug']   = $item['data']->update->slug;
+			$attributes['data-plugin'] = $item['slug'];
 		}
 
 		foreach ( $attributes as $attribute => $value ) {

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -5,11 +5,14 @@
 
 /**
  * List table used on the available updates screen.
+ *
+ * @since 4.X.0
  */
 class Shiny_Updates_List_Table extends WP_List_Table {
 	/**
 	 * The current WordPress version.
 	 *
+	 * @since  4.X.0
 	 * @access protected
 	 *
 	 * @var string
@@ -19,6 +22,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	/**
 	 * The available WordPress version, if applicable.
 	 *
+	 * @since  4.X.0
 	 * @access protected
 	 *
 	 * @var string|false
@@ -39,6 +43,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	 * Prepares the list of items for displaying.
 	 *
 	 * @access public
+	 * @since  4.X.0
 	 * @uses   WP_List_Table::set_pagination_args()
 	 */
 	public function prepare_items() {
@@ -100,6 +105,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	/**
 	 * Message to be displayed when there are no items.
 	 *
+	 * @since  4.X.0
 	 * @access public
 	 */
 	public function no_items() {
@@ -109,9 +115,10 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	/**
 	 * Get a list of columns.
 	 *
+	 * @since  4.X.0
 	 * @access public
 	 *
-	 * @return array
+	 * @return array The list table columns.
 	 */
 	public function get_columns() {
 		$action = sprintf(
@@ -131,17 +138,18 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	/**
 	 * Generates content for a single row of the table
 	 *
+	 * @since  4.X.0
 	 * @access public
 	 *
 	 * @param object $item The current item.
 	 */
 	public function single_row( $item ) {
-		$data = '';
+		$data = "data-type='" . esc_attr( $item['type'] ) . "'";
 
 		if ( 'theme' === $item['type'] ) {
-			$data = "data-slug='" . $item['slug'] . "'";
+			$data .= "data-slug='" . esc_attr( $item['slug'] ) . "'";
 		} else if ( 'plugin' === $item['type'] ) {
-			$data = "data-plugin='" . $item['slug'] . "'";
+			$data .= "data-plugin='" . esc_attr( $item['slug'] ) . "'";
 		}
 
 		echo "<tr $data>";
@@ -152,6 +160,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	/**
 	 * Handles the title column output.
 	 *
+	 * @since  4.X.0
 	 * @access public
 	 *
 	 * @param array $item The current item.
@@ -168,6 +177,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	/**
 	 * Handles the title column output for a theme update item.
 	 *
+	 * @since  4.X.0
 	 * @access public
 	 *
 	 * @param array $item The current item.
@@ -193,6 +203,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	/**
 	 * Handles the title column output for a plugin update item.
 	 *
+	 * @since  4.X.0
 	 * @access public
 	 *
 	 * @param array $item The current item.
@@ -254,6 +265,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	/**
 	 * Handles the title column output for a core update item.
 	 *
+	 * @since  4.X.0
 	 * @access public
 	 *
 	 * @param array $item The current item.
@@ -275,6 +287,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	/**
 	 * Handles the type column output.
 	 *
+	 * @since  4.X.0
 	 * @access public
 	 *
 	 * @param array $item The current item.
@@ -319,11 +332,12 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	/**
 	 * Lists a single core update.
 	 *
-	 * @global string $wp_version
+	 * @global string $wp_version The current WordPress version.
 	 *
+	 * @since  4.X.0
 	 * @access public
 	 *
-	 * @param object  $update
+	 * @param object  $update     The current core update item.
 	 */
 	protected function _list_core_update( $update ) {
 		global $wp_version;

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -54,6 +54,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 		$core_updates = (array) get_core_updates();
 		$plugins      = (array) get_plugin_updates();
 		$themes       = (array) get_theme_updates();
+		$translations = (array) wp_get_translation_updates();
 
 		if ( ! empty( $core_updates ) ) {
 			$this->items[] = array(
@@ -76,6 +77,14 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 				'type' => 'theme',
 				'slug' => $stylesheet,
 				'data' => $theme,
+			);
+		}
+
+		if ( ! empty( $translations ) || 'en_US' !== get_locale() ) {
+			$this->items[] = array(
+				'type' => 'translation',
+				'slug' => 'translation',
+				'data' => $translations,
 			);
 		}
 
@@ -293,6 +302,28 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Handles the title column output for the translations item.
+	 *
+	 * @since  4.X.0
+	 * @access public
+	 *
+	 * @param array $item The current item.
+	 */
+	public function column_title_translation( $item ) {
+		?>
+		<p>
+		<img src="<?php echo esc_url( admin_url( 'images/wordpress-logo.svg' ) ); ?>" width="85" height="85" class="updates-table-screenshot" alt=""/>
+		<strong><?php _e( 'Translations' ); ?></strong>
+		<?php if ( ! $item['data'] ) : ?>
+			<p> <?php _e( 'Your translations are all up to date.' ); ?></p>
+		<?php else : ?>
+			<p><?php _e( 'New translations are available.' ); ?></p>
+		<?php endif; ?>
+		</p>
+		<?php
+	}
+
+	/**
 	 * Handles the type column output.
 	 *
 	 * @since  4.X.0
@@ -309,7 +340,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 				echo __( 'Theme' );
 				break;
 			case 'translation':
-				echo __( 'Translation' );
+				echo __( 'Translations' );
 				break;
 			default:
 				echo __( 'Core' );
@@ -328,6 +359,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 		$slug        = $item['slug'];
 		$checkbox_id = 'checkbox_' . md5( $slug );
 		$form_action = sprintf( 'update-core.php?action=do-%s-upgrade', $item['type'] );
+		$nonce_action = 'translation' === $item['type'] ? 'upgrade-translations' : 'upgrade-core';
 		$data        = '';
 		$attributes  = array();
 
@@ -344,7 +376,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 
 		?>
 		<form method="post" action="<?php echo esc_url( $form_action ); ?>" name="upgrade-all">
-			<?php wp_nonce_field( 'upgrade-core' ); ?>
+			<?php wp_nonce_field( $nonce_action ); ?>
 			<input type="hidden" name="checked[]" id="<?php echo $checkbox_id; ?>" value="<?php echo esc_attr( $slug ); ?>"/>
 			<?php
 			printf(

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -381,7 +381,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 			<input type="hidden" name="checked[]" id="<?php echo $checkbox_id; ?>" value="<?php echo esc_attr( $slug ); ?>"/>
 			<?php
 			printf(
-				'<button type="submit" name="%1$s" id="$1s" class="button update-link" %2$s>%3$s</button>',
+				'<button type="submit" name="%1$s" id="$1$s" class="button update-link" %2$s>%3$s</button>',
 				$checkbox_id,
 				$data,
 				esc_attr__( 'Update' )

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -131,9 +131,10 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	 */
 	public function get_columns() {
 		$action = sprintf(
-			'<form method="post" action="%s" name="upgrade-all">%s<button class="button button-primary" type="submit" value="" name="upgrade-all">%s</button></form>',
+			'<form method="post" action="%s" name="upgrade-all">%s<button class="button button-primary" type="submit" value="" name="upgrade-all" %s>%s</button></form>',
 			'update-core.php?action=do-all-upgrade',
 			wp_nonce_field( 'upgrade-core', '_wpnonce', true, false ),
+			empty( $this->items ) ? 'disabled' : '',
 			esc_attr__( 'Update All' )
 		);
 

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -419,32 +419,35 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 			$current = true;
 		}
 
-		$form_action = 'update-core.php?action=do-core-upgrade';
 		if ( 'development' == $update->response ) {
-			$message = __( 'You are using a development version of WordPress. You can update to the latest nightly build automatically:' );
+			echo '<p>';
+			_e( 'You are using a development version of WordPress. You can update to the latest nightly build automatically.' );
+			echo '</p>';
 		} else {
 			if ( $current ) {
-				$message     = sprintf( __( 'If you need to re-install version %s, you can do so here:' ), $version_string );
-				$form_action = 'update-core.php?action=do-core-reinstall';
+				echo '<p>';
+				printf( __( 'If you need to re-install version %s, you can do so here.' ), $version_string );
+				echo '</p>';
+
+				echo '<form method="post" action="update-core.php?action=do-core-reinstall" name="upgrade" class="upgrade">';
+				wp_nonce_field( 'upgrade-core' );
+				echo '<p>';
+				echo '<input name="version" value="' . esc_attr( $update->current ) . '" type="hidden"/>';
+				echo '<input name="locale" value="' . esc_attr( $update->locale ) . '" type="hidden"/>';
+
+				printf(
+					'<button type="submit" name="upgrade" id="upgrade" class="button">%s</button>',
+					esc_attr__( 'Re-install Now' )
+				);
+
+				echo '</p>';
+
+				echo '</form>';
 			} else {
-				$message = sprintf( __( 'You can update to <a href="https://codex.wordpress.org/Version_%1$s">WordPress %2$s</a> automatically:' ), $update->current, $version_string );
+				echo '<p>';
+				printf( __( 'You can update to <a href="https://codex.wordpress.org/Version_%1$s">WordPress %2$s</a> automatically.' ), $update->current, $version_string );
+				echo '</p>';
 			}
-
 		}
-
-		echo '<p>';
-		echo $message;
-
-		echo '</p>';
-
-		echo '<form method="post" action="' . $form_action . '" name="upgrade" class="upgrade">';
-		wp_nonce_field( 'upgrade-core' );
-		echo '<p>';
-		echo '<input name="version" value="' . esc_attr( $update->current ) . '" type="hidden"/>';
-		echo '<input name="locale" value="' . esc_attr( $update->locale ) . '" type="hidden"/>';
-
-		echo '</p>';
-
-		echo '</form>';
 	}
 }

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -1,0 +1,308 @@
+<?php
+
+class Shiny_Updates_List_Table extends WP_List_Table {
+	/**
+	 * The current WordPress version.
+	 *
+	 * @var string
+	 */
+	protected $cur_wp_version;
+
+	/**
+	 * The available WordPress version, if applicable.
+	 *
+	 * @var string|false
+	 */
+	protected $core_update_version;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct( array(
+			'singular' => __( 'Update' ),
+			'plural'   => __( 'Updates' ),
+		) );
+	}
+
+	/**
+	 * Prepares the list of items for displaying.
+	 *
+	 * @uses WP_List_Table::set_pagination_args()
+	 */
+	public function prepare_items() {
+		global $wp_version;
+
+		$this->cur_wp_version = preg_replace( '/-.*$/', '', $wp_version );
+
+		$core_updates = (array) get_core_updates();
+		$plugins      = (array) get_plugin_updates();
+		$themes       = (array) get_theme_updates();
+
+		if ( ! empty( $core_updates ) ) {
+			$this->items[] = array(
+				'type' => 'core',
+				'slug' => 'core',
+				'data' => $core_updates,
+			);
+		}
+
+		foreach ( $plugins as $plugin_file => $plugin_data ) {
+			$this->items[] = array(
+				'type' => 'plugin',
+				'slug' => $plugin_file,
+				'data' => $plugin_data,
+			);
+		}
+
+		foreach ( $themes as $stylesheet => $theme ) {
+			$this->items[] = array(
+				'type' => 'theme',
+				'slug' => $stylesheet,
+				'data' => $theme,
+			);
+		}
+
+		if ( ! isset( $core_updates[0]->response ) ||
+		     'latest' == $core_updates[0]->response ||
+		     'development' == $core_updates[0]->response ||
+		     version_compare( $core_updates[0]->current, $this->cur_wp_version, '=' )
+		) {
+			$this->core_update_version = false;
+		} else {
+			$this->core_update_version = $core_updates[0]->current;
+		}
+
+		$columns  = $this->get_columns();
+		$hidden   = array();
+		$sortable = $this->get_sortable_columns();
+
+		$this->_column_headers = array( $columns, $hidden, $sortable );
+
+		$this->set_pagination_args( array(
+			'total_items' => count( $this->items ),
+			'per_page'    => count( $this->items ),
+			'total_pages' => 1,
+		) );
+	}
+
+	/**
+	 * Message to be displayed when there are no items
+	 */
+	public function no_items() {
+		_e( 'Your site is up to date, there are no available updates.' );
+	}
+
+	/**
+	 * Get a list of columns.
+	 *
+	 * @return array
+	 */
+	public function get_columns() {
+		$action = sprintf(
+			'<form method="post" action="%s" name="upgrade-all">%s<input class="button button-primary" type="submit" value="%s" name="upgrade-all" /></form>',
+			'update-core.php?action=do-all-upgrade',
+			wp_nonce_field( 'upgrade-core', '_wpnonce', true, false ),
+			esc_attr__( 'Update All' )
+		);
+
+		return array(
+			'title'  => '',
+			'type'   => __( 'Type' ),
+			'action' => $action,
+		);
+	}
+
+	/**
+	 * Handles the title column output.
+	 *
+	 * @param array $item The current item.
+	 */
+	public function column_title( $item ) {
+		if ( 'theme' === $item['type'] ) {
+			/* @var WP_Theme $theme */
+			$theme = $item['data'];
+			?>
+			<p>
+				<img src="<?php echo esc_url( $theme->get_screenshot() ); ?>" width="85" height="64" class="updates-table-screenshot" alt=""/>
+				<strong><?php echo $theme->display( 'Name' ); ?></strong>
+				<?php
+				/* translators: 1: theme version, 2: new version */
+				printf( __( 'You have version %1$s installed. Update to %2$s.' ),
+					$theme->display( 'Version' ),
+					$theme->update['new_version']
+				);
+				?>
+			</p>
+			<?php
+		} elseif ( 'plugin' === $item['type'] ) {
+			$plugin = $item['data'];
+
+			// Get plugin compat for running version of WordPress.
+			if ( isset( $plugin->update->tested ) && version_compare( $plugin->update->tested, $this->cur_wp_version, '>=' ) ) {
+				$compat = '<br />' . sprintf( __( 'Compatibility with WordPress %1$s: 100%% (according to its author)' ), $this->cur_wp_version );
+			} elseif ( isset( $plugin->update->compatibility->{$this->cur_wp_version} ) ) {
+				$compat = $plugin->update->compatibility->{$this->cur_wp_version};
+				$compat = '<br />' . sprintf( __( 'Compatibility with WordPress %1$s: %2$d%% (%3$d "works" votes out of %4$d total)' ), $this->cur_wp_version, $compat->percent, $compat->votes, $compat->total_votes );
+			} else {
+				$compat = '<br />' . sprintf( __( 'Compatibility with WordPress %1$s: Unknown' ), $this->cur_wp_version );
+			}
+			// Get plugin compat for updated version of WordPress.
+			if ( $this->core_update_version ) {
+				if ( isset( $plugin->update->tested ) && version_compare( $plugin->update->tested, $this->core_update_version, '>=' ) ) {
+					$compat .= '<br />' . sprintf( __( 'Compatibility with WordPress %1$s: 100%% (according to its author)' ), $this->core_update_version );
+				} elseif ( isset( $plugin->update->compatibility->{$this->core_update_version} ) ) {
+					$update_compat = $plugin->update->compatibility->{$this->core_update_version};
+					$compat .= '<br />' . sprintf( __( 'Compatibility with WordPress %1$s: %2$d%% (%3$d "works" votes out of %4$d total)' ), $this->core_update_version, $update_compat->percent, $update_compat->votes, $update_compat->total_votes );
+				} else {
+					$compat .= '<br />' . sprintf( __( 'Compatibility with WordPress %1$s: Unknown' ), $this->core_update_version );
+				}
+			}
+			// Get the upgrade notice for the new plugin version.
+			if ( isset( $plugin->update->upgrade_notice ) ) {
+				$upgrade_notice = '<br />' . strip_tags( $plugin->update->upgrade_notice );
+			} else {
+				$upgrade_notice = '';
+			}
+
+			$details_url = self_admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $plugin->update->slug . '&section=changelog&TB_iframe=true&width=640&height=662' );
+			$details     = sprintf(
+				'<a href="%1$s" class="thickbox open-plugin-details-modal" aria-label="%2$s">%3$s</a>',
+				esc_url( $details_url ),
+				/* translators: 1: plugin name, 2: version number */
+				esc_attr( sprintf( __( 'View %1$s version %2$s details' ), $plugin->Name, $plugin->update->new_version ) ),
+				/* translators: %s: plugin version */
+				sprintf( __( 'View version %s details.' ), $plugin->update->new_version )
+			);
+			?>
+			<p>
+				<strong><?php echo $plugin->Name; ?></strong>
+				<?php
+				/* translators: 1: plugin version, 2: new version */
+				printf( __( 'You have version %1$s installed. Update to %2$s.' ),
+					$plugin->Version,
+					$plugin->update->new_version
+				);
+				echo ' ' . $details . $compat . $upgrade_notice;
+				?>
+			</p>
+			<?php
+		} else if ( 'core' === $item['type'] ) {
+			?>
+			<p>
+				<img src="<?php echo esc_url( admin_url( 'images/wordpress-logo.svg' ) ); ?>" width="85" height="85" class="updates-table-screenshot" alt=""/>
+				<strong><?php _e( 'WordPress' ); ?></strong>
+				<?php
+				foreach ( (array) $item['data'] as $update ) {
+					$this->_list_core_update( $update );
+				}
+				?>
+			</p>
+			<?php
+		} else {
+			var_dump( $item );
+		}
+	}
+
+	/**
+	 * Handles the type column output.
+	 *
+	 * @param array $item The current item.
+	 */
+	public function column_type( $item ) {
+		switch ( $item['type'] ) {
+			case 'plugin':
+				echo __( 'Plugin' );
+				break;
+			case 'theme':
+				echo __( 'Theme' );
+				break;
+			case 'translation':
+				echo __( 'Translation' );
+				break;
+			default:
+				echo __( 'Core' );
+				break;
+		}
+	}
+
+	/**
+	 * Handles the action column output.
+	 *
+	 * @param array $item The current item.
+	 */
+	public function column_action( $item ) {
+		$slug        = $item['slug'];
+		$checkbox_id = 'checkbox_' . md5( $slug );
+		$form_action = sprintf( 'update-core.php?action=do-%s-upgrade', $item['type'] );
+		?>
+		<form method="post" action="<?php echo esc_url( $form_action ); ?>" name="upgrade-all">
+			<?php wp_nonce_field( 'upgrade-core' ); ?>
+			<input type="hidden" name="checked[]" id="<?php echo $checkbox_id; ?>" value="<?php echo esc_attr( $slug ); ?>"/>
+			<?php submit_button( esc_attr__( 'Update' ), 'button', $checkbox_id, false ); ?>
+		</form>
+		<?php
+	}
+
+	/**
+	 *
+	 * @global string $wp_version
+	 *
+	 * @param object  $update
+	 */
+	protected function _list_core_update( $update ) {
+		global $wp_version;
+
+		if ( 'en_US' == $update->locale && 'en_US' == get_locale() ) {
+			$version_string = $update->current;
+		} // If the only available update is a partial builds, it doesn't need a language-specific version string.
+		elseif ( 'en_US' == $update->locale && $update->packages->partial && $wp_version == $update->partial_version && ( $updates = get_core_updates() ) && 1 == count( $updates ) ) {
+			$version_string = $update->current;
+		} else {
+			$version_string = sprintf( "%s&ndash;<code>%s</code>", $update->current, $update->locale );
+		}
+
+		$current = false;
+
+		if ( ! isset( $update->response ) || 'latest' == $update->response ) {
+			$current = true;
+		}
+
+		$form_action  = 'update-core.php?action=do-core-upgrade';
+		$show_buttons = true;
+		if ( 'development' == $update->response ) {
+			$message  = __( 'You are using a development version of WordPress. You can update to the latest nightly build automatically or download the nightly build and install it manually:' );
+			$download = __( 'Download nightly build' );
+		} else {
+			if ( $current ) {
+				$message     = sprintf( __( 'If you need to re-install version %s, you can do so here or download the package and re-install manually:' ), $version_string );
+				$form_action = 'update-core.php?action=do-core-reinstall';
+			} else {
+				$message      = sprintf( __( 'You can update to <a href="https://codex.wordpress.org/Version_%1$s">WordPress %2$s</a> automatically or download the package and install it manually:' ), $update->current, $version_string );
+				$show_buttons = false;
+			}
+
+			$download = sprintf( __( 'Download %s' ), $version_string );
+		}
+
+		echo '<p>';
+		echo $message;
+
+		if ( $show_buttons ) {
+			echo '&nbsp;<a href="' . esc_url( $update->download ) . '">' . $download . '</a>&nbsp;';
+		}
+		echo '</p>';
+
+		echo '<form method="post" action="' . $form_action . '" name="upgrade" class="upgrade">';
+		wp_nonce_field( 'upgrade-core' );
+		echo '<p>';
+		echo '<input name="version" value="' . esc_attr( $update->current ) . '" type="hidden"/>';
+		echo '<input name="locale" value="' . esc_attr( $update->locale ) . '" type="hidden"/>';
+
+		echo '</p>';
+
+		echo '</form>';
+
+	}
+
+}

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -374,11 +374,12 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 		foreach ( $attributes as $attribute => $value ) {
 			$data .= $attribute . '="' . esc_attr( $value ) . '" ';
 		}
-
 		?>
 		<form method="post" action="<?php echo esc_url( $form_action ); ?>" name="upgrade-all">
 			<?php wp_nonce_field( $nonce_action ); ?>
-			<input type="hidden" name="checked[]" id="<?php echo $checkbox_id; ?>" value="<?php echo esc_attr( $slug ); ?>"/>
+			<?php if ( 'core' !== $item['type'] ) : ?>
+				<input type="hidden" name="checked[]" id="<?php echo $checkbox_id; ?>" value="<?php echo esc_attr( $slug ); ?>"/>
+			<?php endif; ?>
 			<?php
 			printf(
 				'<button type="submit" name="%1$s" id="$1$s" class="button update-link" %2$s>%3$s</button>',

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * This file holds the shiny updates list table class.
+ *
+ * @package Shiny_Updates
  */
 
 /**
@@ -316,14 +318,14 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	public function column_title_translation( $item ) {
 		?>
 		<p>
-		<span class="dashicons dashicons-translation"></span>
-		<strong><?php _e( 'Translations' ); ?></strong>
+			<span class="dashicons dashicons-translation"></span>
+			<strong><?php _e( 'Translations' ); ?></strong>
+		</p>
 		<?php if ( ! $item['data'] ) : ?>
 			<p> <?php _e( 'Your translations are all up to date.' ); ?></p>
 		<?php else : ?>
 			<p><?php _e( 'New translations are available.' ); ?></p>
 		<?php endif; ?>
-		</p>
 		<?php
 	}
 
@@ -383,7 +385,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 			<?php if ( 'core' === $item['type'] ) : ?>
 				<input name="version" value="<?php echo esc_attr( $item['data'][0]->current ); ?>" type="hidden"/>
 				<input name="locale" value="<?php echo esc_attr( $item['data'][0]->locale ); ?>" type="hidden"/>
-			<?php else: ?>
+			<?php else : ?>
 				<input type="hidden" name="checked[]" id="<?php echo $checkbox_id; ?>" value="<?php echo esc_attr( $slug ); ?>"/>
 			<?php endif; ?>
 			<?php
@@ -417,7 +419,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 		elseif ( 'en_US' == $update->locale && $update->packages->partial && $wp_version == $update->partial_version && ( $updates = get_core_updates() ) && 1 == count( $updates ) ) {
 			$version_string = $update->current;
 		} else {
-			$version_string = sprintf( "%s&ndash;<code>%s</code>", $update->current, $update->locale );
+			$version_string = sprintf( '%s&ndash;<code>%s</code>', $update->current, $update->locale );
 		}
 
 		$current = false;

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -1,8 +1,16 @@
 <?php
+/**
+ * This file holds the shiny updates list table class.
+ */
 
+/**
+ * List table used on the available updates screen.
+ */
 class Shiny_Updates_List_Table extends WP_List_Table {
 	/**
 	 * The current WordPress version.
+	 *
+	 * @access protected
 	 *
 	 * @var string
 	 */
@@ -10,6 +18,8 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 
 	/**
 	 * The available WordPress version, if applicable.
+	 *
+	 * @access protected
 	 *
 	 * @var string|false
 	 */
@@ -28,7 +38,8 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	/**
 	 * Prepares the list of items for displaying.
 	 *
-	 * @uses WP_List_Table::set_pagination_args()
+	 * @access public
+	 * @uses   WP_List_Table::set_pagination_args()
 	 */
 	public function prepare_items() {
 		global $wp_version;
@@ -87,7 +98,9 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * Message to be displayed when there are no items
+	 * Message to be displayed when there are no items.
+	 *
+	 * @access public
 	 */
 	public function no_items() {
 		_e( 'Your site is up to date, there are no available updates.' );
@@ -95,6 +108,8 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 
 	/**
 	 * Get a list of columns.
+	 *
+	 * @access public
 	 *
 	 * @return array
 	 */
@@ -116,6 +131,8 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	/**
 	 * Handles the title column output.
 	 *
+	 * @access public
+	 *
 	 * @param array $item The current item.
 	 */
 	public function column_title( $item ) {
@@ -129,6 +146,8 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 
 	/**
 	 * Handles the title column output for a theme update item.
+	 *
+	 * @access public
 	 *
 	 * @param array $item The current item.
 	 */
@@ -152,6 +171,8 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 
 	/**
 	 * Handles the title column output for a plugin update item.
+	 *
+	 * @access public
 	 *
 	 * @param array $item The current item.
 	 */
@@ -212,6 +233,8 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	/**
 	 * Handles the title column output for a core update item.
 	 *
+	 * @access public
+	 *
 	 * @param array $item The current item.
 	 */
 	public function column_title_core( $item ) {
@@ -230,6 +253,8 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 
 	/**
 	 * Handles the type column output.
+	 *
+	 * @access public
 	 *
 	 * @param array $item The current item.
 	 */
@@ -253,6 +278,8 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	/**
 	 * Handles the action column output.
 	 *
+	 * @access public
+	 *
 	 * @param array $item The current item.
 	 */
 	public function column_action( $item ) {
@@ -269,8 +296,11 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Lists a single core update.
 	 *
 	 * @global string $wp_version
+	 *
+	 * @access public
 	 *
 	 * @param object  $update
 	 */
@@ -326,7 +356,5 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 		echo '</p>';
 
 		echo '</form>';
-
 	}
-
 }

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -312,7 +312,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	public function column_title_translation( $item ) {
 		?>
 		<p>
-		<img src="<?php echo esc_url( admin_url( 'images/wordpress-logo.svg' ) ); ?>" width="85" height="85" class="updates-table-screenshot" alt=""/>
+		<span class="dashicons dashicons-translation"></span>
 		<strong><?php _e( 'Translations' ); ?></strong>
 		<?php if ( ! $item['data'] ) : ?>
 			<p> <?php _e( 'Your translations are all up to date.' ); ?></p>

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -388,8 +388,8 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 			<?php endif; ?>
 			<?php
 			printf(
-				'<button type="submit" name="%1$s" id="$1$s" class="button update-link" %2$s>%3$s</button>',
-				$checkbox_id,
+				'<button type="submit" name="%1$s" id="%1$s" class="button update-link" %2$s>%3$s</button>',
+				'core' === $item['type'] ? 'upgrade' : $checkbox_id,
 				$data,
 				esc_attr__( 'Update' )
 			);

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -290,7 +290,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 		<form method="post" action="<?php echo esc_url( $form_action ); ?>" name="upgrade-all">
 			<?php wp_nonce_field( 'upgrade-core' ); ?>
 			<input type="hidden" name="checked[]" id="<?php echo $checkbox_id; ?>" value="<?php echo esc_attr( $slug ); ?>"/>
-			<?php submit_button( esc_attr__( 'Update' ), 'button', $checkbox_id, false ); ?>
+			<?php submit_button( esc_attr__( 'Update' ), 'button update-link', $checkbox_id, false ); ?>
 		</form>
 		<?php
 	}

--- a/src/class-shiny-updates.php
+++ b/src/class-shiny-updates.php
@@ -63,6 +63,9 @@ class Shiny_Updates {
 
 		// Plugin modal installations.
 		add_action( 'install_plugins_pre_plugin-information', array( $this, 'install_plugin_information' ), 9 );
+
+		// Translation updates.
+		add_action( 'wp_ajax_update-translations', 'wp_ajax_update_translations', -1 );
 	}
 
 	/**

--- a/src/class-shiny-updates.php
+++ b/src/class-shiny-updates.php
@@ -148,48 +148,48 @@ class Shiny_Updates {
 			'plugins'    => $plugins,
 			'totals'     => $totals,
 			'l10n'       => array(
-				'searchResults'             => __( 'Search results for &#8220;%s&#8221;' ),
-				'noPlugins'                 => __( 'You do not appear to have any plugins available at this time.' ),
-				'noItemsSelected'           => __( 'Please select at least one item to perform this action on.' ),
-				'updating'                  => __( 'Updating...' ), // No ellipsis.
-				'updated'                   => __( 'Updated!' ),
-				'update'                    => __( 'Update' ),
-				'updateNow'                 => __( 'Update Now' ),
-				'updateFailedShort'         => __( 'Update Failed!' ),
+				'searchResults'      => __( 'Search results for &#8220;%s&#8221;' ),
+				'noPlugins'          => __( 'You do not appear to have any plugins available at this time.' ),
+				'noItemsSelected'    => __( 'Please select at least one item to perform this action on.' ),
+				'updating'           => __( 'Updating...' ), // No ellipsis.
+				'updated'            => __( 'Updated!' ),
+				'update'             => __( 'Update' ),
+				'updateNow'          => __( 'Update Now' ),
+				'updateFailedShort'  => __( 'Update Failed!' ),
 				/* translators: Error string for a failed update */
-				'updateFailed'              => __( 'Update Failed: %s' ),
+				'updateFailed'       => __( 'Update Failed: %s' ),
 				/* translators: Plugin name and version */
-				'updatingLabel'             => __( 'Updating %s...' ), // No ellipsis.
+				'updatingLabel'      => __( 'Updating %s...' ), // No ellipsis.
 				/* translators: Plugin name and version */
-				'updatedLabel'              => __( '%s updated!' ),
+				'updatedLabel'       => __( '%s updated!' ),
 				/* translators: Plugin name and version */
-				'updateFailedLabel'         => __( '%s update failed' ),
+				'updateFailedLabel'  => __( '%s update failed' ),
 				/* translators: JavaScript accessible string */
-				'updatingMsg'               => __( 'Updating... please wait.' ), // No ellipsis.
+				'updatingMsg'        => __( 'Updating... please wait.' ), // No ellipsis.
 				/* translators: JavaScript accessible string */
-				'updatedMsg'                => __( 'Update completed successfully.' ),
+				'updatedMsg'         => __( 'Update completed successfully.' ),
 				/* translators: JavaScript accessible string */
-				'updateCancel'              => __( 'Update canceled.' ),
-				'beforeunload'              => __( 'Plugin updates may not complete if you navigate away from this page.' ),
-				'installNow'                => __( 'Install Now' ),
-				'installing'                => __( 'Installing...' ),
-				'installed'                 => __( 'Installed!' ),
-				'installFailedShort'        => __( 'Install Failed!' ),
+				'updateCancel'       => __( 'Update canceled.' ),
+				'beforeunload'       => __( 'Plugin updates may not complete if you navigate away from this page.' ),
+				'installNow'         => __( 'Install Now' ),
+				'installing'         => __( 'Installing...' ),
+				'installed'          => __( 'Installed!' ),
+				'installFailedShort' => __( 'Install Failed!' ),
 				/* translators: Error string for a failed installation. */
-				'installFailed'             => __( 'Installation failed: %s' ),
+				'installFailed'      => __( 'Installation failed: %s' ),
 				/* translators: Plugin/Theme name and version */
-				'installingLabel'           => __( 'Installing %s...' ), // no ellipsis
+				'installingLabel'    => __( 'Installing %s...' ), // no ellipsis
 				/* translators: Plugin/Theme name and version */
-				'installedLabel'            => __( '%s installed!' ),
+				'installedLabel'     => __( '%s installed!' ),
 				/* translators: Plugin/Theme name and version */
-				'installFailedLabel'        => __( '%s installation failed' ),
-				'installingMsg'             => __( 'Installing... please wait.' ),
-				'installedMsg'              => __( 'Installation completed successfully.' ),
+				'installFailedLabel' => __( '%s installation failed' ),
+				'installingMsg'      => __( 'Installing... please wait.' ),
+				'installedMsg'       => __( 'Installation completed successfully.' ),
 				/* translators: Plugin name */
-				'aysDelete'                 => __( 'Are you sure you want to delete %s?' ),
-				'deleting'                  => __( 'Deleting...' ),
-				'deleteFailed'              => __( 'Deletion failed: %s' ),
-				'deleted'                   => __( 'Deleted!' ),
+				'aysDelete'          => __( 'Are you sure you want to delete %s?' ),
+				'deleting'           => __( 'Deleting...' ),
+				'deleteFailed'       => __( 'Deletion failed: %s' ),
+				'deleted'            => __( 'Deleted!' ),
 			),
 		) );
 
@@ -347,7 +347,7 @@ class Shiny_Updates {
 				</div>
 			</div>
 			<div class="wp-full-overlay-main">
-				<iframe src="{{ data.preview_url }}" title="<?php esc_attr_e( 'Preview' ); ?>" />
+				<iframe src="{{ data.preview_url }}" title="<?php esc_attr_e( 'Preview' ); ?>"></iframe>
 			</div>
 		</script>
 	<?php

--- a/src/class-shiny-updates.php
+++ b/src/class-shiny-updates.php
@@ -147,6 +147,7 @@ class Shiny_Updates {
 				'noItemsSelected'           => __( 'Please select at least one item to perform this action on.' ),
 				'updating'                  => __( 'Updating...' ), // No ellipsis.
 				'updated'                   => __( 'Updated!' ),
+				'update'                    => __( 'Update' ),
 				'updateNow'                 => __( 'Update Now' ),
 				'updateFailedShort'         => __( 'Update Failed!' ),
 				/* translators: Error string for a failed update */

--- a/src/class-shiny-updates.php
+++ b/src/class-shiny-updates.php
@@ -111,7 +111,14 @@ class Shiny_Updates {
 	 * @param string $hook Current admin page.
 	 */
 	function enqueue_scripts( $hook ) {
-		if ( ! in_array( $hook, array( 'plugins.php', 'plugin-install.php', 'themes.php', 'theme-install.php' ), true ) ) {
+		if ( ! in_array( $hook, array(
+			'plugins.php',
+			'plugin-install.php',
+			'themes.php',
+			'theme-install.php',
+			'update-core.php',
+		), true )
+		) {
 			return;
 		}
 

--- a/src/class-shiny-updates.php
+++ b/src/class-shiny-updates.php
@@ -66,6 +66,9 @@ class Shiny_Updates {
 
 		// Translation updates.
 		add_action( 'wp_ajax_update-translations', 'wp_ajax_update_translations', -1 );
+
+		// Core updates.
+		add_action( 'wp_ajax_update-core', 'wp_ajax_update_core', -1 );
 	}
 
 	/**

--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -199,6 +199,10 @@ tr.active + tr.plugin-update-tr:not(.updated) .plugin-update .notice-error.notic
 	display: none;
 }
 
+.update-core-php .notice.notice-warning + p {
+	display: block;
+}
+
 .wp-list-table.updates .manage-column.column-type {
 	width: 10%;
 }

--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -207,6 +207,10 @@ tr.active + tr.plugin-update-tr:not(.updated) .plugin-update .notice-error.notic
 	width: 10%;
 }
 
+.wp-list-table.updates .manage-column.column-action form {
+	margin: 0;
+}
+
 .wp-list-table.updates .dashicons-translation {
 	width: 85px;
 	height: 85px;

--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -190,6 +190,23 @@ tr.active + tr.plugin-update-tr:not(.updated) .plugin-update .notice-error.notic
 	background-color: #e5f5fa;
 }
 
+.update-core-php .wrap > h2,
+.update-core-php .wrap > p,
+.update-core-php .wrap > .core-updates,
+.update-core-php .wrap > [name=upgrade-translations],
+.update-core-php .wrap > [name=upgrade-plugins],
+.update-core-php .wrap > [name=upgrade-themes] {
+	display: none;
+}
+
+.wp-list-table.updates .manage-column.column-type {
+	width: 10%;
+}
+
+.wp-list-table.updates .manage-column.column-action {
+	width: 10%;
+}
+
 @media aural {
 	.wrap .notice p:before,
 	.theme .notice:before,

--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -207,6 +207,14 @@ tr.active + tr.plugin-update-tr:not(.updated) .plugin-update .notice-error.notic
 	width: 10%;
 }
 
+.wp-list-table.updates .dashicons-translation {
+	width: 85px;
+	height: 85px;
+	font-size: 85px;
+	float: left;
+	margin: 0 10px 5px 0;
+}
+
 @media aural {
 	.wrap .notice p:before,
 	.theme .notice:before,

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -106,7 +106,7 @@ window.wp = window.wp || {};
 	 *
 	 * @type {jQuery}
 	 */
-	wp.updates.$elToReturnFocusToFromCredentialsModal;
+	wp.updates.$elToReturnFocusToFromCredentialsModal = undefined;
 
 	/**
 	 * Adds or updates an admin notice.

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -1164,7 +1164,7 @@
 	};
 
 	$( function() {
-		var $theList         = $( '#the-list' ),
+		var $theList         = $( '.wp-list-table:not(.updates)' ),
 			$bulkActionForm  = $( '#bulk-action-form' ),
 			$filesystemModal = $( '#request-filesystem-credentials-dialog' );
 
@@ -1552,10 +1552,10 @@
 
 			switch ( updateType ) {
 				case 'plugin':
-					// wp.updates.updatePlugin( $itemRow.data( 'plugin' ), $itemRow.data( 'slug' ) );
+					wp.updates.updatePlugin( $itemRow.data( 'plugin' ), $itemRow.data( 'slug' ) );
 					break;
 				case 'theme':
-					// wp.updates.updateTheme( $itemRow.data( 'slug' ) );
+					wp.updates.updateTheme( $itemRow.data( 'slug' ) );
 					break;
 				case 'translation':
 					wp.updates.updateTranslations();

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -900,7 +900,7 @@
 		$message   = $updateRow.find( '.update-link' ).addClass( 'updating-message' );
 		message    = wp.updates.l10n.updatingMsg;
 
-		if ( !wp.updates.updateLock ) {
+		if ( ! wp.updates.updateLock ) {
 			$message.attr( 'aria-label', message );
 
 			if ( $message.html() !== wp.updates.l10n.updating ) {
@@ -944,16 +944,15 @@
 	 * @param {object} response Response from the server.
 	 */
 	wp.updates.updateTranslationsError = function( response ) {
+		var errorMessage = wp.updates.l10n.updateFailed.replace( '%s', response.error ),
+		    $message = $( 'tr[data-type="translation"]' ).find( '.update-link' ).text( wp.updates.l10n.updateFailedShort ).removeClass( 'updating-message' );
+
 		if ( response.errorCode && 'unable_to_connect_to_filesystem' === response.errorCode && wp.updates.shouldRequestFilesystemCredentials ) {
 			wp.updates.credentialError( response, 'update-translations' );
 			return;
 		}
 
-		var errorMessage = wp.updates.l10n.updateFailed.replace( '%s', response.error );
-
-		var $message = $( 'tr[data-type="translation"]' ).find( '.update-link' ).text( wp.updates.l10n.updateFailedShort ).removeClass( 'updating-message' );
-
-		setTimeout( function () {
+		setTimeout( function() {
 			$message.text( wp.updates.l10n.update );
 		}, 500 );
 
@@ -974,7 +973,7 @@
 		$message   = $updateRow.find( '.update-link' ).addClass( 'updating-message' );
 		message    = wp.updates.l10n.updatingMsg;
 
-		if ( !wp.updates.updateLock ) {
+		if ( ! wp.updates.updateLock ) {
 			$message.attr( 'aria-label', message );
 
 			if ( $message.html() !== wp.updates.l10n.updating ) {
@@ -1023,16 +1022,15 @@
 	 * @param {object} response Response from the server.
 	 */
 	wp.updates.updateCoreError = function( response ) {
+		var errorMessage = wp.updates.l10n.updateFailed.replace( '%s', response.error ),
+		    $message = $( 'tr[data-type="core"]' ).find( '.update-link' ).text( wp.updates.l10n.updateFailedShort ).removeClass( 'updating-message' );
+
 		if ( response.errorCode && 'unable_to_connect_to_filesystem' === response.errorCode && wp.updates.shouldRequestFilesystemCredentials ) {
 			wp.updates.credentialError( response, 'update-translations' );
 			return;
 		}
 
-		var errorMessage = wp.updates.l10n.updateFailed.replace( '%s', response.error );
-
-		var $message = $( 'tr[data-type="core"]' ).find( '.update-link' ).text( wp.updates.l10n.updateFailedShort ).removeClass( 'updating-message' );
-
-		setTimeout( function () {
+		setTimeout( function() {
 			$message.text( wp.updates.l10n.update );
 		}, 500 );
 
@@ -1616,13 +1614,13 @@
 		 *
 		 * @param {Event} event Event interface.
 		 */
-		$document.on( 'click', '.wp-list-table.updates .update-link', function ( event ) {
+		$document.on( 'click', '.wp-list-table.updates .update-link', function( event ) {
 			var $itemRow   = $( event.target ).parents( 'tr' ),
 			    updateType = $itemRow.data( 'type' );
 
 			event.preventDefault();
 
-			if ( wp.updates.shouldRequestFilesystemCredentials && !wp.updates.updateLock ) {
+			if ( wp.updates.shouldRequestFilesystemCredentials && ! wp.updates.updateLock ) {
 				wp.updates.requestFilesystemCredentials( event );
 			}
 

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -314,7 +314,7 @@ window.wp = window.wp || {};
 		} else if ( 'plugin-install' === pagenow ) {
 			$updateMessage = $( '.plugin-card-' + response.slug ).find( '.update-now' ).removeClass( 'updating-message' ).addClass( 'button-disabled updated-message' );
 		} else if ( 'update-core' === pagenow ) {
-			$updateMessage = $( 'tr[data-plugin="' + plugin + '"]' ).find( '.update-link' ).removeClass( 'updating-message' ).addClass( 'button-disabled updated-message' );
+			$updateMessage = $( 'tr[data-plugin="' + response.plugin + '"]' ).find( '.update-link' ).removeClass( 'updating-message' ).addClass( 'button-disabled updated-message' );
 		}
 
 		$updateMessage
@@ -378,7 +378,7 @@ window.wp = window.wp || {};
 		} else if ( 'update-core' === pagenow ) {
 			$message = $( 'tr[data-plugin="' + response.plugin ).find( '.update-link' ).text( wp.updates.l10n.updateFailedShort ).removeClass( 'updating-message' );
 
-			setTimeout( function () {
+			setTimeout( function() {
 				$message.text( wp.updates.l10n.update );
 			}, 500 );
 		}
@@ -686,7 +686,7 @@ window.wp = window.wp || {};
 		} else if ( 'update-core' === pagenow ) {
 			$notice = $( 'tr[data-slug="' + response.slug ).find( '.update-link' ).text( wp.updates.l10n.updateFailedShort ).removeClass( 'updating-message' );
 
-			setTimeout( function () {
+			setTimeout( function() {
 				$notice.text( wp.updates.l10n.update );
 			}, 500 );
 		} else {

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -1007,8 +1007,6 @@
 
 		wp.a11y.speak( wp.updates.l10n.updatedMsg, 'polite' );
 
-		wp.updates.decrementCount( 'translations' );
-
 		$document.trigger( 'wp-core-update-success', response );
 
 		window.location = response.redirect;
@@ -1026,7 +1024,7 @@
 		    $message = $( 'tr[data-type="core"]' ).find( '.update-link' ).text( wp.updates.l10n.updateFailedShort ).removeClass( 'updating-message' );
 
 		if ( response.errorCode && 'unable_to_connect_to_filesystem' === response.errorCode && wp.updates.shouldRequestFilesystemCredentials ) {
-			wp.updates.credentialError( response, 'update-translations' );
+			wp.updates.credentialError( response, 'update-core' );
 			return;
 		}
 

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -1,8 +1,7 @@
-/* global pagenow */
-window.wp = window.wp || {};
-
 (function( $, wp ) {
 	var $document = $( document );
+
+	wp = wp || {};
 
 	/**
 	 * The WP Updates object.

--- a/src/update.php
+++ b/src/update.php
@@ -239,3 +239,52 @@ function su_theme_update_row( $theme_key, $theme ) {
 
 	echo '</p></div></td></tr>';
 }
+
+/**
+ * Prints CSS used for the shiny update table.
+ */
+function su_admin_head() {
+	?>
+	<style>
+		.wrap > h2,
+		.wrap > p,
+		.wrap > .core-updates,
+		.wrap > [name=upgrade-plugins],
+		.wrap > [name=upgrade-themes] {
+			display: none;
+		}
+
+		.wp-list-table.updates .manage-column.column-type {
+			width: 10%;
+		}
+
+		.wp-list-table.updates .manage-column.column-action {
+			width: 10%;
+		}
+	</style>
+	<?php
+}
+
+add_action( 'admin_head-update-core.php', 'su_admin_head' );
+
+/**
+ * Displays the shiny update table.
+ *
+ * Includes core, plugin and theme updates.
+ */
+function su_update_table() {
+	?>
+	<div class="shiny-update-table">
+		<h2><?php _e( 'Available Updates' ); ?></h2>
+		<?php
+		require_once( 'class-shiny-updates-list-table.php' );
+
+		$updates_table = new Shiny_Updates_List_Table();
+		$updates_table->prepare_items();
+		$updates_table->display();
+		?>
+	</div>
+	<?php
+}
+
+add_action( 'core_upgrade_preamble', 'su_update_table' );

--- a/src/update.php
+++ b/src/update.php
@@ -16,6 +16,7 @@ function su_new_update_rows() {
 	add_action( 'admin_init', 'su_plugin_update_rows' );
 	add_action( 'admin_init', 'su_theme_update_rows' );
 }
+
 add_action( 'admin_init', 'su_new_update_rows', 1 );
 
 /**
@@ -187,7 +188,7 @@ function su_theme_update_row( $theme_key, $theme ) {
 
 	$wp_list_table = _get_list_table( 'WP_MS_Themes_List_Table' );
 
-	$active = $theme->is_allowed( 'network' ) ? ' active': '';
+	$active = $theme->is_allowed( 'network' ) ? ' active' : '';
 
 	echo '<tr class="plugin-update-tr' . $active . '" id="' . esc_attr( $theme->get_stylesheet() . '-update' ) . '" data-slug="' . esc_attr( $theme->get_stylesheet() ) . '"><td colspan="' . $wp_list_table->get_column_count() . '" class="plugin-update colspanchange"><div class="update-message notice inline notice-warning notice-alt"><p>';
 	if ( ! current_user_can( 'update_themes' ) ) {

--- a/src/update.php
+++ b/src/update.php
@@ -253,7 +253,7 @@ function su_update_table() {
 		<?php
 		require_once( 'class-shiny-updates-list-table.php' );
 
-		// Todo: Use _get_list_table()
+		// Todo: Use _get_list_table().
 		$updates_table = new Shiny_Updates_List_Table();
 		$updates_table->prepare_items();
 		$updates_table->display();

--- a/src/update.php
+++ b/src/update.php
@@ -249,6 +249,7 @@ function su_admin_head() {
 		.wrap > h2,
 		.wrap > p,
 		.wrap > .core-updates,
+		.wrap > [name=upgrade-translations],
 		.wrap > [name=upgrade-plugins],
 		.wrap > [name=upgrade-themes] {
 			display: none;

--- a/src/update.php
+++ b/src/update.php
@@ -241,34 +241,6 @@ function su_theme_update_row( $theme_key, $theme ) {
 }
 
 /**
- * Prints CSS used for the shiny update table.
- */
-function su_admin_head() {
-	?>
-	<style>
-		.wrap > h2,
-		.wrap > p,
-		.wrap > .core-updates,
-		.wrap > [name=upgrade-translations],
-		.wrap > [name=upgrade-plugins],
-		.wrap > [name=upgrade-themes] {
-			display: none;
-		}
-
-		.wp-list-table.updates .manage-column.column-type {
-			width: 10%;
-		}
-
-		.wp-list-table.updates .manage-column.column-action {
-			width: 10%;
-		}
-	</style>
-	<?php
-}
-
-add_action( 'admin_head-update-core.php', 'su_admin_head' );
-
-/**
  * Displays the shiny update table.
  *
  * Includes core, plugin and theme updates.

--- a/src/update.php
+++ b/src/update.php
@@ -252,6 +252,7 @@ function su_update_table() {
 		<?php
 		require_once( 'class-shiny-updates-list-table.php' );
 
+		// Todo: Use _get_list_table()
 		$updates_table = new Shiny_Updates_List_Table();
 		$updates_table->prepare_items();
 		$updates_table->display();

--- a/tests/fixtures/shiny-updates.js
+++ b/tests/fixtures/shiny-updates.js
@@ -14,12 +14,12 @@ window.shinyUpdates = {
 	'updatedMsg': 'Update completed successfully.',
 	'updateCancel': 'Update canceled.',
 	'beforeunload': 'Plugin updates may not complete if you navigate away from this page.',
-	'installNow': 'Install Now' ,
+	'installNow': 'Install Now',
 	'installing': 'Installing...',
 	'installed': 'Installed!',
 	'installFailedShort': 'Install Failed!',
 	'installFailed': 'Installation failed: %s',
-	'installingLabel': 'Installing %s...', // no ellipsis
+	'installingLabel': 'Installing %s...', // No ellipsis
 	'installedLabel': '%s installed!',
 	'installFailedLabel': '%s installation failed',
 	'installingMsg': 'Installing... please wait.',

--- a/tests/fixtures/wp-updates-settings.js
+++ b/tests/fixtures/wp-updates-settings.js
@@ -6,6 +6,7 @@ window._wpUpdatesSettings = {
 		'noItemsSelected': 'Please select at least one item to perform this action on.',
 		'updating': 'Updating...',
 		'updated': 'Updated!',
+		'update': 'Update',
 		'updateNow': 'Update Now',
 		'updateFailedShort': 'Update Failed!',
 		'updateFailed': 'Update Failed: %s',

--- a/tests/fixtures/wp-updates-settings.js
+++ b/tests/fixtures/wp-updates-settings.js
@@ -17,12 +17,12 @@ window._wpUpdatesSettings = {
 		'updatedMsg': 'Update completed successfully.',
 		'updateCancel': 'Update canceled.',
 		'beforeunload': 'Plugin updates may not complete if you navigate away from this page.',
-		'installNow': 'Install Now' ,
+		'installNow': 'Install Now',
 		'installing': 'Installing...',
 		'installed': 'Installed!',
 		'installFailedShort': 'Install Failed!',
 		'installFailed': 'Installation failed: %s',
-		'installingLabel': 'Installing %s...', // no ellipsis
+		'installingLabel': 'Installing %s...', // No ellipsis
 		'installedLabel': '%s installed!',
 		'installFailedLabel': '%s installation failed',
 		'installingMsg': 'Installing... please wait.',


### PR DESCRIPTION
As per #5, this is a MVP for a single list table for all available updates (core, plugins, themes, translations).

Each update can be done via ajax, even translation updates and core updates. Successful core updates will still result in a redirect to the about page.

It's not perfect and likely has some bugs, but it's a good base for further discussions on the ticket.

Here's a screenshot of how it currently looks like:

<img width="1440" alt="screen shot 2016-05-16 at 13 33 37" src="https://cloud.githubusercontent.com/assets/841956/15289961/cc20fee6-1b75-11e6-8204-944d0a145b1b.png">

Note that the missing 'Check Again' button to fetch new updates has already been re-added to the page. Otherwise the layout is the same right now.