### PR TITLE
Improve updates table responsiveness

### DIFF
--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -138,6 +138,18 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Get a list of CSS classes for the WP_List_Table table tag.
+	 *
+	 * @since 4.X.0
+	 * @access protected
+	 *
+	 * @return array List of CSS classes for the table tag.
+	 */
+	protected function get_table_classes() {
+		return array( 'widefat', 'striped', $this->_args['plural'] );
+	}
+
+	/**
 	 * Display the table
 	 *
 	 * @since 4.X.0

--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -213,6 +213,7 @@ tr.active + tr.plugin-update-tr:not(.updated) .plugin-update .notice-error.notic
 
 .update-core-php .wordpress-updates-table .tablenav .actions {
 	padding: 2px 0;
+	display: block;
 }
 
 .update-core-php .wordpress-updates-table .tablenav .button {
@@ -222,7 +223,8 @@ tr.active + tr.plugin-update-tr:not(.updated) .plugin-update .notice-error.notic
 
 .update-core-php .wordpress-updates-table .tablenav .displaying-num {
 	display: inline-block;
-	margin-top: 5px;
+	margin: 5px 7px 0 0;
+	position: static;
 }
 
 .wp-list-table.updates {
@@ -238,8 +240,10 @@ tr.active + tr.plugin-update-tr:not(.updated) .plugin-update .notice-error.notic
 	width: 80%;
 }
 
-.wp-list-table.updates .column-action {
-	text-align: right;
+@media screen and (min-width: 782px) {
+	.wp-list-table.updates .column-action {
+		text-align: right;
+	}
 }
 
 .wp-list-table.updates .manage-column.column-action form {
@@ -260,7 +264,7 @@ tr.active + tr.plugin-update-tr:not(.updated) .plugin-update .notice-error.notic
 }
 
 .wp-list-table.updates .updates-table-screenshot + p {
-	float: left;
+	margin-left: 105px;
 }
 
 .wordpress-reinstall-card {


### PR DESCRIPTION
This improves the layout of the updates table across different browsers and screen sizes.

Basically what it does: Do not hide the top tablenav ('Update All') on mobile, remove absolute positioning for bottom tablenav, fix image alignment on mobile and table layout in Firefox.

Fixes #130. See #116.

Some Screenshots:

<img width="529" alt="ipad-portrait" src="https://cloud.githubusercontent.com/assets/841956/15453976/d3a612d2-202a-11e6-960e-56532d8a2e3a.png">
<img width="403" alt="iphone-portrait" src="https://cloud.githubusercontent.com/assets/841956/15453977/d3a7b4c0-202a-11e6-8c0d-88cdae90f504.png">
<img width="699" alt="iphone-landscape" src="https://cloud.githubusercontent.com/assets/841956/15453975/d3a5b83c-202a-11e6-85f6-2a0b7c856b71.png">
<img width="424" alt="iphone-portrait-collapsed" src="https://cloud.githubusercontent.com/assets/841956/15453978/d3a9e984-202a-11e6-8a2d-8eaede7dc5f0.png">
<img width="704" alt="screen shot 2016-05-22 at 13 26 08" src="https://cloud.githubusercontent.com/assets/841956/15453987/efc6358c-202a-11e6-9768-ecd109746f1d.png">