### PR TITLE
Make beforeunload message generic

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -80,7 +80,7 @@ function su_enqueue_scripts( $hook ) {
 			'updatedMsg'         => __( 'Update completed successfully.' ),
 			/* translators: JavaScript accessible string */
 			'updateCancel'       => __( 'Update canceled.' ),
-			'beforeunload'       => __( 'Plugin updates may not complete if you navigate away from this page.' ),
+			'beforeunload'       => __( 'Updates may not complete if you navigate away from this page.' ),
 			'installNow'         => __( 'Install Now' ),
 			'installing'         => __( 'Installing...' ),
 			'installed'          => __( 'Installed!' ),

--- a/tests/fixtures/shiny-updates.js
+++ b/tests/fixtures/shiny-updates.js
@@ -13,7 +13,7 @@ window.shinyUpdates = {
 	'updatingMsg': 'Updating... please wait.',
 	'updatedMsg': 'Update completed successfully.',
 	'updateCancel': 'Update canceled.',
-	'beforeunload': 'Plugin updates may not complete if you navigate away from this page.',
+	'beforeunload': 'Updates may not complete if you navigate away from this page.',
 	'installNow': 'Install Now',
 	'installing': 'Installing...',
 	'installed': 'Installed!',

--- a/tests/fixtures/wp-updates-settings.js
+++ b/tests/fixtures/wp-updates-settings.js
@@ -16,7 +16,7 @@ window._wpUpdatesSettings = {
 		'updatingMsg': 'Updating... please wait.',
 		'updatedMsg': 'Update completed successfully.',
 		'updateCancel': 'Update canceled.',
-		'beforeunload': 'Plugin updates may not complete if you navigate away from this page.',
+		'beforeunload': 'Updates may not complete if you navigate away from this page.',
 		'installNow': 'Install Now',
 		'installing': 'Installing...',
 		'installed': 'Installed!',


### PR DESCRIPTION
Old string:

`Plugin updates may not complete if you navigate away from this page.``

New string:

`Updates may not complete if you navigate away from this page.`

Fixes #136