### PR TITLE
Decrement update counter when on update-core.php page

### DIFF
--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -239,8 +239,11 @@
 				break;
 		}
 
-		itemCount = $itemCount.eq( 0 ).text();
-		itemCount = parseInt( itemCount, 10 ) - 1;
+		if ( $itemCount ) {
+			itemCount = $itemCount.eq( 0 ).text();
+			itemCount = parseInt( itemCount, 10 ) - 1;
+		}
+
 		if ( itemCount < 0 || isNaN( itemCount ) ) {
 			return;
 		}
@@ -1013,6 +1016,8 @@
 		$message.attr( 'aria-label', wp.updates.l10n.updated ).text( wp.updates.l10n.updated );
 
 		wp.a11y.speak( wp.updates.l10n.updatedMsg, 'polite' );
+
+		wp.updates.decrementCount( type );
 
 		$document.trigger( 'wp-' + type + '-update-success', response );
 


### PR DESCRIPTION
Fixes an error where `$itemCount` is not set for update types other than themes and plugins.

Fixes #137.