### PR TITLE
remove admin color scheme from 'Update All' button

### DIFF
--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -209,7 +209,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 						<span class="displaying-num">
 							<?php printf( _n( '%s item', '%s items', $total_items ), number_format_i18n( $total_items ) ); ?>
 						</span>
-						<button class="button button-primary update-link" data-type="all" type="submit" value="" name="upgrade-all">
+						<button class="button update-link" data-type="all" type="submit" value="" name="upgrade-all">
 							<?php esc_attr_e( 'Update All' ); ?>
 						</button>
 					</form>

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -209,7 +209,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 						<span class="displaying-num">
 							<?php printf( _n( '%s item', '%s items', $total_items ), number_format_i18n( $total_items ) ); ?>
 						</span>
-						<button class="button update-link" data-type="all" type="submit" value="" name="upgrade-all">
+						<button class="button button-primary update-link" data-type="all" type="submit" value="" name="upgrade-all">
 							<?php esc_attr_e( 'Update All' ); ?>
 						</button>
 					</form>

--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -224,6 +224,13 @@ tr.active + tr.plugin-update-tr:not(.updated) .plugin-update .notice-error.notic
 	position: relative;
 }
 
+.wp-core-ui .button-primary.update-link {
+	color: #555;
+	background: #f7f7f7;
+	box-shadow: 0 1px 0 #cccccc;
+	text-shadow: none;
+}
+
 .wp-list-table.updates {
 	border-collapse: collapse;
 }

--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -221,7 +221,7 @@ tr.active + tr.plugin-update-tr:not(.updated) .plugin-update .notice-error.notic
 .update-core-php .wordpress-updates-table .tablenav .displaying-num {
 	display: inline-block;
 	margin: 5px 7px 0 0;
-	position: static;
+	position: relative;
 }
 
 .wp-list-table.updates {

--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -221,7 +221,7 @@ tr.active + tr.plugin-update-tr:not(.updated) .plugin-update .notice-error.notic
 .update-core-php .wordpress-updates-table .tablenav .displaying-num {
 	display: inline-block;
 	margin: 5px 7px 0 0;
-	position: relative;
+	position: static;
 }
 
 .wp-core-ui .button-primary.update-link {


### PR DESCRIPTION
this allows the 'Update All' button to appear as all other 'Update' buttons and solves issue with color of spinner

Solves issue #157 

![screenshot_02](https://cloud.githubusercontent.com/assets/1296790/15635039/c7f90daa-2588-11e6-9504-8d692a2f5583.png)
