### PR TITLE
Fix core update notification when running stable

### DIFF
--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -68,7 +68,18 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 		$themes       = (array) get_theme_updates();
 		$translations = (array) wp_get_translation_updates();
 
-		if ( ! empty( $core_updates ) ) {
+		if ( ! isset( $core_updates[0]->response ) ||
+		     'latest' === $core_updates[0]->response ||
+		     version_compare( $core_updates[0]->current, $this->cur_wp_version, '=' )
+		) {
+			$this->core_update_version = false;
+		} else {
+			$this->core_update_version = $core_updates[0]->current;
+		}
+
+		$this->has_available_updates = ( $this->core_update_version || ! empty( $plugins ) || ! empty( $themes ) || ! empty( $translations ) );
+
+		if ( ! empty( $core_updates ) && $this->core_update_version ) {
 			$this->items[] = array(
 				'type' => 'core',
 				'slug' => 'core',
@@ -98,20 +109,6 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 				'slug' => 'translations',
 				'data' => $translations,
 			);
-		}
-
-		if ( ! isset( $core_updates[0]->response ) ||
-		     'latest' === $core_updates[0]->response ||
-		     'development' === $core_updates[0]->response ||
-		     version_compare( $core_updates[0]->current, $this->cur_wp_version, '=' )
-		) {
-			$this->core_update_version = false;
-		} else {
-			$this->core_update_version = $core_updates[0]->current;
-		}
-
-		if ( $this->core_update_version || ! empty( $plugins ) || ! empty( $themes ) || ! empty( $translations ) ) {
-			$this->has_available_updates = true;
 		}
 
 		$columns  = $this->get_columns();

--- a/src/functions.php
+++ b/src/functions.php
@@ -608,11 +608,7 @@ function su_update_table() {
 	<?php
 	$core_updates = (array) get_core_updates();
 
-	if ( ! isset( $core_updates[1] ) ) {
-		return;
-	}
-
-	$update = $core_updates[1];
+	$update = isset( $core_updates[1] ) ? $core_updates[1] : $core_updates[0];
 
 	if ( 'en_US' === $update->locale &&
 	     'en_US' === get_locale() ||


### PR DESCRIPTION
Not necessarily tied to multisite, but this bug was caught on a multisite install.

Fixes an issue where an empty core update row was displayed on `update-core.php` when running 4.5.2 stable. Instead, the re-install option should be shown.

Fixes #154.