### PR TITLE
Revert/ajax referer

### DIFF
--- a/src/ajax-actions.php
+++ b/src/ajax-actions.php
@@ -625,7 +625,7 @@ function wp_ajax_update_core() {
 	$update = find_core_update( $version, $locale );
 
 	if ( ! $update ) {
-		$status['error'] = __( 'Installation failed' );
+		$status['error'] = __( 'Installation failed.' );
 		wp_send_json_error( $status );
 	}
 
@@ -655,7 +655,7 @@ function wp_ajax_update_core() {
 		wp_send_json_error( $status );
 	} else if ( false === $result ) {
 		// These aren't actual errors.
-		$status['error'] = __( 'Installation failed' );
+		$status['error'] = __( 'Installation failed.' );
 		wp_send_json_error( $status );
 	} else {
 		wp_send_json_success( $status );

--- a/src/ajax-actions.php
+++ b/src/ajax-actions.php
@@ -13,6 +13,8 @@
  * @since 4.X.0
  */
 function wp_ajax_install_theme() {
+	check_ajax_referer( 'updates' );
+
 	if ( empty( $_POST['slug'] ) ) {
 		wp_send_json_error( array(
 			'slug'      => '',
@@ -21,14 +23,15 @@ function wp_ajax_install_theme() {
 		) );
 	}
 
-	if ( ! check_ajax_referer( 'updates', false, false ) || ! current_user_can( 'install_themes' ) ) {
-		wp_send_json_error( array( 'error' => __( 'You do not have sufficient permissions to install themes on this site.' ) ) );
-	}
-
 	$status = array(
 		'install' => 'theme',
 		'slug'    => sanitize_key( wp_unslash( $_POST['slug'] ) ),
 	);
+
+	if ( ! current_user_can( 'install_themes' ) ) {
+		$status['error'] = __( 'You do not have sufficient permissions to install themes on this site.' );
+		wp_send_json_error( $status );
+	}
 
 	include_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
 	include_once( ABSPATH . 'wp-admin/includes/theme.php' );
@@ -79,6 +82,8 @@ function wp_ajax_install_theme() {
  * @since 4.X.0
  */
 function wp_ajax_update_theme() {
+	check_ajax_referer( 'updates' );
+
 	if ( empty( $_POST['slug'] ) ) {
 		wp_send_json_error( array(
 			'slug'      => '',
@@ -87,18 +92,18 @@ function wp_ajax_update_theme() {
 		) );
 	}
 
-	if ( ! check_ajax_referer( 'updates', false, false ) || ! current_user_can( 'update_themes' ) ) {
-		wp_send_json_error( array( 'error' => __( 'You do not have sufficient permissions to update themes on this site.' ) ) );
-	}
-
 	$stylesheet = sanitize_key( wp_unslash( $_POST['slug'] ) );
-
 	$status     = array(
 		'update'     => 'theme',
 		'slug'       => $stylesheet,
 		'oldVersion' => sprintf( __( 'Version %s' ), wp_get_theme( $stylesheet )->get( 'Version' ) ),
 		'newVersion' => '',
 	);
+
+	if ( ! current_user_can( 'update_themes' ) ) {
+		$status['error'] = __( 'You do not have sufficient permissions to update themes on this site.' );
+		wp_send_json_error( $status );
+	}
 
 	include_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
 
@@ -159,6 +164,8 @@ function wp_ajax_update_theme() {
  * @since 4.X.0
  */
 function wp_ajax_delete_theme() {
+	check_ajax_referer( 'updates' );
+
 	if ( empty( $_POST['slug'] ) ) {
 		wp_send_json_error( array(
 			'slug'      => '',
@@ -167,16 +174,16 @@ function wp_ajax_delete_theme() {
 		) );
 	}
 
-	if ( ! check_ajax_referer( 'updates', false, false ) || ! current_user_can( 'delete_themes' ) ) {
-		wp_send_json_error( array( 'error' => __( 'You do not have sufficient permissions to delete themes on this site.' ) ) );
-	}
-
 	$stylesheet = sanitize_key( wp_unslash( $_POST['slug'] ) );
-
-	$status = array(
+	$status     = array(
 		'delete' => 'theme',
 		'slug'   => $stylesheet,
 	);
+
+	if ( ! current_user_can( 'delete_themes' ) ) {
+		$status['error'] = __( 'You do not have sufficient permissions to delete themes on this site.' );
+		wp_send_json_error( $status );
+	}
 
 	if ( ! wp_get_theme( $stylesheet )->exists() ) {
 		$status['error'] = __( 'The requested theme does not exist.' );
@@ -224,18 +231,21 @@ function wp_ajax_delete_theme() {
  * @since 4.X.0
  */
 function wp_ajax_install_plugin() {
+	check_ajax_referer( 'updates' );
+
 	if ( empty( $_POST['slug'] ) ) {
 		wp_send_json_error( array( 'errorCode' => 'no_plugin_specified' ) );
-	}
-
-	if ( ! check_ajax_referer( 'updates', false, false ) || ! current_user_can( 'install_plugins' ) ) {
-		wp_send_json_error( array( 'error' => __( 'You do not have sufficient permissions to install plugins on this site.' ) ) );
 	}
 
 	$status = array(
 		'install' => 'plugin',
 		'slug'    => sanitize_key( wp_unslash( $_POST['slug'] ) ),
 	);
+
+	if ( ! current_user_can( 'install_plugins' ) ) {
+		$status['error'] = __( 'You do not have sufficient permissions to install plugins on this site.' );
+		wp_send_json_error( $status );
+	}
 
 	include_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
 	include_once( ABSPATH . 'wp-admin/includes/plugin-install.php' );
@@ -302,12 +312,10 @@ function wp_ajax_install_plugin() {
  * @see Plugin_Upgrader
  */
 function wpsu_ajax_update_plugin() {
+	check_ajax_referer( 'updates' );
+
 	if ( empty( $_POST['plugin'] ) || empty( $_POST['slug'] ) ) {
 		wp_send_json_error( array( 'errorCode' => 'no_plugin_specified' ) );
-	}
-
-	if ( ! check_ajax_referer( 'updates', false, false ) || ! current_user_can( 'update_plugins' ) ) {
-		wp_send_json_error( array( 'error' => __( 'You do not have sufficient permissions to update plugins for this site.' ) ) );
 	}
 
 	$plugin      = plugin_basename( sanitize_text_field( wp_unslash( $_POST['plugin'] ) ) );
@@ -324,6 +332,11 @@ function wpsu_ajax_update_plugin() {
 
 	if ( $plugin_data['Version'] ) {
 		$status['oldVersion'] = sprintf( __( 'Version %s' ), $plugin_data['Version'] );
+	}
+
+	if ( ! current_user_can( 'update_plugins' ) ) {
+		$status['error'] = __( 'You do not have sufficient permissions to update plugins for this site.' );
+		wp_send_json_error( $status );
 	}
 
 	include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
@@ -369,6 +382,7 @@ function wpsu_ajax_update_plugin() {
 	} else if ( is_wp_error( $result ) ) {
 		$status['error'] = $result->get_error_message();
 		wp_send_json_error( $status );
+
 	} else if ( false === $result ) {
 		global $wp_filesystem;
 
@@ -394,12 +408,10 @@ function wpsu_ajax_update_plugin() {
  * @since 4.X.0
  */
 function wp_ajax_delete_plugin() {
+	check_ajax_referer( 'updates' );
+
 	if ( empty( $_POST['slug'] ) || empty( $_POST['plugin'] ) ) {
 		wp_send_json_error( array( 'errorCode' => 'no_plugin_specified' ) );
-	}
-
-	if ( ! check_ajax_referer( 'updates', false, false ) || ! current_user_can( 'delete_plugins' ) ) {
-		wp_send_json_error( array( 'error' => __( 'You do not have sufficient permissions to delete plugins for this site.' ) ) );
 	}
 
 	$plugin      = plugin_basename( sanitize_text_field( wp_unslash( $_POST['plugin'] ) ) );
@@ -411,6 +423,11 @@ function wp_ajax_delete_plugin() {
 		'plugin'     => $plugin,
 		'pluginName' => $plugin_data['Name'],
 	);
+
+	if ( ! current_user_can( 'delete_plugins' ) ) {
+		$status['error'] = __( 'You do not have sufficient permissions to delete plugins for this site.' );
+		wp_send_json_error( $status );
+	}
 
 	if ( is_plugin_active( $plugin ) ) {
 		$status['error'] = __( 'You cannot delete a plugin while it is active on the main site.' );
@@ -458,13 +475,15 @@ function wp_ajax_delete_plugin() {
  * @global string        $hook_suffix
  */
 function wp_ajax_search_plugins() {
+	check_ajax_referer( 'updates' );
+
 	global $wp_list_table, $hook_suffix;
 	$hook_suffix = 'plugins.php';
 
 	$status        = array();
 	$wp_list_table = _get_list_table( 'WP_Plugins_List_Table' );
 
-	if ( ! check_ajax_referer( 'updates', false, false ) || ! $wp_list_table->ajax_user_can() ) {
+	if ( ! $wp_list_table->ajax_user_can() ) {
 		$status['error'] = __( 'You do not have sufficient permissions to manage plugins on this site.' );
 		wp_send_json_error( $status );
 	}
@@ -490,13 +509,15 @@ function wp_ajax_search_plugins() {
  * @global string        $hook_suffix
  */
 function wp_ajax_search_install_plugins() {
+	check_ajax_referer( 'updates' );
+
 	global $wp_list_table, $hook_suffix;
 	$hook_suffix = 'plugin-install.php';
 
 	$status        = array();
 	$wp_list_table = _get_list_table( 'WP_Plugin_Install_List_Table' );
 
-	if ( ! check_ajax_referer( 'updates', false, false ) || ! $wp_list_table->ajax_user_can() ) {
+	if ( ! $wp_list_table->ajax_user_can() ) {
 		$status['error'] = __( 'You do not have sufficient permissions to manage plugins on this site.' );
 		wp_send_json_error( $status );
 	}
@@ -521,13 +542,9 @@ function wp_ajax_search_install_plugins() {
  * @see Language_Pack_Upgrader
  */
 function wp_ajax_update_translations() {
-	if ( ! check_ajax_referer( 'updates', false, false ) ||
-	     (
-		     ! current_user_can( 'update_core' ) &&
-		     ! current_user_can( 'update_plugins' ) &&
-		     ! current_user_can( 'update_themes' )
-	     )
-	) {
+	check_ajax_referer( 'updates' );
+
+	if ( ! current_user_can( 'update_core' ) && ! current_user_can( 'update_plugins' ) && ! current_user_can( 'update_themes' ) ) {
 		$status['error'] = __( 'You do not have sufficient permissions to update this site.' );
 		wp_send_json_error( $status );
 	}
@@ -541,7 +558,7 @@ function wp_ajax_update_translations() {
 
 	$skin     = new Automatic_Upgrader_Skin( compact( 'url', 'nonce', 'title', 'context' ) );
 	$upgrader = new Language_Pack_Upgrader( $skin );
-	$result   = $upgrader->bulk_upgrade( array(), array( 'clear_update_cache' => false ) );
+	$result   = $upgrader->bulk_upgrade();
 
 	$status = array(
 		'update' => 'translation',
@@ -588,12 +605,9 @@ function wp_ajax_update_translations() {
  * @see Core_Upgrader
  */
 function wp_ajax_update_core() {
-	$status = array(
-		'update'   => 'core',
-		'redirect' => esc_url( self_admin_url( 'about.php?updated' ) ),
-	);
+	check_ajax_referer( 'updates' );
 
-	if ( ! check_ajax_referer( 'updates', false, false ) || ! current_user_can( 'update_core' ) ) {
+	if ( ! current_user_can( 'update_core' ) ) {
 		$status['error'] = __( 'You do not have sufficient permissions to update this site.' );
 		wp_send_json_error( $status );
 	}
@@ -606,9 +620,13 @@ function wp_ajax_update_core() {
 	$update = find_core_update( $version, $locale );
 
 	if ( ! $update ) {
-		$status['error'] = __( 'Installation failed.' );
-		wp_send_json_error( $status );
+		return;
 	}
+
+	$status = array(
+		'update'   => 'core',
+		'redirect' => esc_url( self_admin_url( 'about.php?updated' ) ),
+	);
 
 	include_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
 
@@ -636,7 +654,7 @@ function wp_ajax_update_core() {
 		wp_send_json_error( $status );
 	} else if ( false === $result ) {
 		// These aren't actual errors.
-		$status['error'] = __( 'Installation failed.' );
+		$status['error'] = __( 'Installation Failed' );
 		wp_send_json_error( $status );
 	} else {
 		wp_send_json_success( $status );

--- a/src/ajax-actions.php
+++ b/src/ajax-actions.php
@@ -558,7 +558,7 @@ function wp_ajax_update_translations() {
 
 	$skin     = new Automatic_Upgrader_Skin( compact( 'url', 'nonce', 'title', 'context' ) );
 	$upgrader = new Language_Pack_Upgrader( $skin );
-	$result   = $upgrader->bulk_upgrade();
+	$result   = $upgrader->bulk_upgrade( array(), array( 'clear_update_cache' => false ) );
 
 	$status = array(
 		'update' => 'translation',
@@ -607,6 +607,11 @@ function wp_ajax_update_translations() {
 function wp_ajax_update_core() {
 	check_ajax_referer( 'updates' );
 
+	$status = array(
+		'update'   => 'core',
+		'redirect' => esc_url( self_admin_url( 'about.php?updated' ) ),
+	);
+
 	if ( ! current_user_can( 'update_core' ) ) {
 		$status['error'] = __( 'You do not have sufficient permissions to update this site.' );
 		wp_send_json_error( $status );
@@ -620,13 +625,9 @@ function wp_ajax_update_core() {
 	$update = find_core_update( $version, $locale );
 
 	if ( ! $update ) {
-		return;
+		$status['error'] = __( 'Installation failed' );
+		wp_send_json_error( $status );
 	}
-
-	$status = array(
-		'update'   => 'core',
-		'redirect' => esc_url( self_admin_url( 'about.php?updated' ) ),
-	);
 
 	include_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
 
@@ -654,7 +655,7 @@ function wp_ajax_update_core() {
 		wp_send_json_error( $status );
 	} else if ( false === $result ) {
 		// These aren't actual errors.
-		$status['error'] = __( 'Installation Failed' );
+		$status['error'] = __( 'Installation failed' );
 		wp_send_json_error( $status );
 	} else {
 		wp_send_json_success( $status );


### PR DESCRIPTION
Moving the ajax referer checks like that breaks error messages for themes and plugins. Let’s keep it the way it is for now.