### PR TITLE
Re-use existing update handlers in update-core.

### DIFF
--- a/src/ajax-actions.php
+++ b/src/ajax-actions.php
@@ -614,7 +614,7 @@ function wp_ajax_update_core() {
 		wp_send_json_error( $status );
 	}
 
-	$reinstall = isset( $_POST['reinstall'] ) ? (bool) $_POST['reinstall'] : false;
+	$reinstall = isset( $_POST['reinstall'] ) ? 'true' === wp_unslash( $_POST['reinstall'] ) : false;
 	$version   = isset( $_POST['version'] ) ? sanitize_text_field( wp_unslash( $_POST['version'] ) ) : false;
 	$locale    = isset( $_POST['locale'] ) ? sanitize_text_field( wp_unslash( $_POST['locale'] ) ) : 'en_US';
 

--- a/src/ajax-actions.php
+++ b/src/ajax-actions.php
@@ -622,7 +622,7 @@ function wp_ajax_update_core() {
 		wp_send_json_error( $status );
 	}
 
-	$reinstall = isset( $_POST['reinstall'] ) ? 'true' === wp_unslash( $_POST['reinstall'] ) : false;
+	$reinstall = isset( $_POST['reinstall'] ) ? 'true' === sanitize_text_field( wp_unslash( $_POST['reinstall'] ) ) : false;
 	$version   = isset( $_POST['version'] ) ? sanitize_text_field( wp_unslash( $_POST['version'] ) ) : false;
 	$locale    = isset( $_POST['locale'] ) ? sanitize_text_field( wp_unslash( $_POST['locale'] ) ) : 'en_US';
 

--- a/src/ajax-actions.php
+++ b/src/ajax-actions.php
@@ -544,6 +544,10 @@ function wp_ajax_search_install_plugins() {
 function wp_ajax_update_translations() {
 	check_ajax_referer( 'updates' );
 
+	$status = array(
+		'update' => 'translations',
+	);
+
 	if ( ! current_user_can( 'update_core' ) && ! current_user_can( 'update_plugins' ) && ! current_user_can( 'update_themes' ) ) {
 		$status['error'] = __( 'You do not have sufficient permissions to update this site.' );
 		wp_send_json_error( $status );
@@ -551,18 +555,9 @@ function wp_ajax_update_translations() {
 
 	include_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
 
-	$url     = 'update-core.php?action=do-translation-upgrade';
-	$nonce   = 'upgrade-translations';
-	$title   = __( 'Update Translations' );
-	$context = WP_CONTENT_DIR;
-
-	$skin     = new Automatic_Upgrader_Skin( compact( 'url', 'nonce', 'title', 'context' ) );
+	$skin     = new Automatic_Upgrader_Skin();
 	$upgrader = new Language_Pack_Upgrader( $skin );
 	$result   = $upgrader->bulk_upgrade();
-
-	$status = array(
-		'update' => 'translation',
-	);
 
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		$status['debug'] = $upgrader->skin->get_upgrade_messages();
@@ -574,9 +569,11 @@ function wp_ajax_update_translations() {
 
 	if ( is_array( $result ) && ! empty( $result[0] ) ) {
 		wp_send_json_success( $status );
+
 	} else if ( is_wp_error( $result ) ) {
 		$status['error'] = $result->get_error_message();
 		wp_send_json_error( $status );
+
 	} else if ( false === $result ) {
 		global $wp_filesystem;
 
@@ -607,15 +604,19 @@ function wp_ajax_update_translations() {
 function wp_ajax_update_core() {
 	check_ajax_referer( 'updates' );
 
+	$status = array(
+		'update'   => 'core',
+		'redirect' => esc_url( self_admin_url( 'about.php?updated' ) ),
+	);
+
 	if ( ! current_user_can( 'update_core' ) ) {
 		$status['error'] = __( 'You do not have sufficient permissions to update this site.' );
 		wp_send_json_error( $status );
 	}
 
 	$reinstall = isset( $_POST['reinstall'] ) ? (bool) $_POST['reinstall'] : false;
-
-	$version = isset( $_POST['version'] ) ? sanitize_text_field( wp_unslash( $_POST['version'] ) ) : false;
-	$locale  = isset( $_POST['locale'] ) ? sanitize_text_field( wp_unslash( $_POST['locale'] ) ) : 'en_US';
+	$version   = isset( $_POST['version'] ) ? sanitize_text_field( wp_unslash( $_POST['version'] ) ) : false;
+	$locale    = isset( $_POST['locale'] ) ? sanitize_text_field( wp_unslash( $_POST['locale'] ) ) : 'en_US';
 
 	$update = find_core_update( $version, $locale );
 
@@ -623,23 +624,13 @@ function wp_ajax_update_core() {
 		return;
 	}
 
-	$status = array(
-		'update'   => 'core',
-		'redirect' => esc_url( self_admin_url( 'about.php?updated' ) ),
-	);
-
-	include_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
-
 	if ( $reinstall ) {
 		$update->response = 'reinstall';
 	}
 
-	$url     = 'update-core.php?action=do-core-upgrade';
-	$nonce   = 'upgrade-translations';
-	$title   = __( 'Update Core' );
-	$context = ABSPATH;
+	include_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
 
-	$skin     = new Automatic_Upgrader_Skin( compact( 'url', 'nonce', 'title', 'context' ) );
+	$skin     = new Automatic_Upgrader_Skin();
 	$upgrader = new Core_Upgrader( $skin );
 	$result   = $upgrader->upgrade( $update, array(
 		'allow_relaxed_file_ownership' => ! $reinstall && isset( $update->new_files ) && ! $update->new_files,
@@ -649,18 +640,28 @@ function wp_ajax_update_core() {
 		$status['debug'] = $upgrader->skin->get_upgrade_messages();
 	}
 
-	if ( is_wp_error( $result ) ) {
+	if ( is_string( $result ) ) {
+		wp_send_json_success( $status );
+
+	} else if ( is_wp_error( $result ) ) {
 		$status['error'] = $result->get_error_message();
 		wp_send_json_error( $status );
+
 	} else if ( false === $result ) {
-		// These aren't actual errors.
-		$status['error'] = __( 'Installation Failed' );
+		global $wp_filesystem;
+
+		$status['errorCode'] = 'unable_to_connect_to_filesystem';
+		$status['error']     = __( 'Unable to connect to the filesystem. Please confirm your credentials.' );
+
+		// Pass through the error from WP_Filesystem if one was raised.
+		if ( $wp_filesystem instanceof WP_Filesystem_Base && is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->get_error_code() ) {
+			$status['error'] = $wp_filesystem->errors->get_error_message();
+		}
+
 		wp_send_json_error( $status );
-	} else {
-		wp_send_json_success( $status );
 	}
 
 	// An unhandled error occurred.
-	$status['error'] = __( 'Installation failed.' );
+	$status['error'] = __( 'Core update failed.' );
 	wp_send_json_error( $status );
 }

--- a/src/ajax-actions.php
+++ b/src/ajax-actions.php
@@ -625,7 +625,8 @@ function wp_ajax_update_core() {
 	}
 
 	if ( $reinstall ) {
-		$update->response = 'reinstall';
+		$update->response    = 'reinstall';
+		$status['reinstall'] = 'reinstall';
 	}
 
 	include_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -162,7 +162,7 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 
 		$this->screen->render_screen_reader_content( 'heading_list' );
 		?>
-		<table class="wp-list-table <?php echo implode( ' ', $this->get_table_classes() ); ?>">
+		<table id="wp-updates-table" class="wp-list-table <?php echo implode( ' ', $this->get_table_classes() ); ?>">
 			<thead>
 			<tr>
 				<?php $this->print_column_headers(); ?>

--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -57,6 +57,7 @@
 	content: '\f147';
 }
 
+.button-primary.updating-message:before,
 .theme-install.updating-message:before {
 	color: #fff;
 }

--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -225,30 +225,30 @@ tr.active + tr.plugin-update-tr:not(.updated) .plugin-update .notice-error.notic
 	position: static;
 }
 
-.wp-list-table.updates {
+#wp-updates-table {
 	border-collapse: collapse;
 }
 
-.wp-list-table.updates tr {
+#wp-updates-table tr {
 	border-bottom: 1px solid #e5e5e5;
 }
 
-.wp-list-table.updates .manage-column.column-title {
+#wp-updates-table .manage-column.column-title {
 	padding-left: 115px;
 	width: 80%;
 }
 
 @media screen and (min-width: 782px) {
-	.wp-list-table.updates .column-action {
+	#wp-updates-table .column-action {
 		text-align: right;
 	}
 }
 
-.wp-list-table.updates .manage-column.column-action form {
+#wp-updates-table .manage-column.column-action form {
 	margin: 0;
 }
 
-.wp-list-table.updates .dashicons-translation {
+#wp-updates-table .dashicons-translation {
 	width: 85px;
 	height: 85px;
 	font-size: 85px;
@@ -256,12 +256,12 @@ tr.active + tr.plugin-update-tr:not(.updated) .plugin-update .notice-error.notic
 	margin: 0 10px 5px 0;
 }
 
-.wp-list-table.updates .updates-table-screenshot {
+#wp-updates-table .updates-table-screenshot {
 	padding: 7px 15px 0 5px;
 	width: 85px;
 }
 
-.wp-list-table.updates .updates-table-screenshot + p {
+#wp-updates-table .updates-table-screenshot + p {
 	margin-left: 105px;
 }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -37,20 +37,20 @@ function su_enqueue_scripts( $hook ) {
 		return;
 	}
 
-	$plugins = $totals = array();
+	$plugins = $totals = new stdClass;
 
 	if ( isset( $GLOBALS['totals'] ) ) {
 		$totals = $GLOBALS['totals'];
 	}
 
-	if ( ! isset( $GLOBALS['plugins'] ) ) {
-		$GLOBALS['plugins'] = array(
-			'all' => get_plugins(),
-		);
-	}
+	if ( strpos( $hook, 'plugin' ) ) {
+		if ( ! isset( $GLOBALS['plugins'] ) ) {
+			$GLOBALS['plugins'] = array( 'all' => get_plugins() );
+		}
 
-	foreach ( $GLOBALS['plugins'] as $key => $list ) {
-		$plugins[ $key ] = array_keys( (array) $list );
+		foreach ( $GLOBALS['plugins'] as $key => $list ) {
+			$plugins->$key = array_keys( (array) $list );
+		}
 	}
 
 	wp_enqueue_style( 'shiny-updates', plugin_dir_url( __FILE__ ) . 'css/shiny-updates.css' );

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -1037,11 +1037,15 @@
 	 * @since 4.X.0
 	 *
 	 * @callback updateItemSuccess
-	 * @param {object} response           Response from the server.
-	 * @param {string} response.slug      Optional. Slug of the theme or plugin that was updated.
-	 * @param {string} response.update    The type of update. 'core', 'plugin', 'theme', or 'translations'.
-	 * @param {string} response.reinstall Optional. Whether this was a reinstall request or not.
-	 * @param {string} response.redirect  Optional. URL to redirect to after updating Core.
+	 * @param {object} response            Response from the server.
+	 * @param {string} response.update     The type of update. 'core', 'plugin', 'theme', or 'translations'.
+	 * @param {string} response.slug       Optional. Slug of the theme or plugin that was updated.
+	 * @param {string} response.reinstall  Optional. Whether this was a reinstall request or not.
+	 * @param {string} response.redirect   Optional. URL to redirect to after updating Core.
+	 * @param {string} response.plugin     Optional. Basename of the plugin that was updated.
+	 * @param {string} response.pluginName Optional. Name of the plugin that was updated.
+	 * @param {string} response.oldVersion Optional. Old version of the theme or plugin.
+	 * @param {string} response.newVersion Optional. New version of the theme or plugin.
 	 */
 	wp.updates.updateItemSuccess = function( response ) {
 		var type = response.update,
@@ -1079,12 +1083,14 @@
 	 * @since 4.X.0
 	 *
 	 * @callback updateItemError
-	 * @param {object} response           Response from the server.
-	 * @param {string} response.slug      Optional. Slug of the theme or plugin that was updated.
-	 * @param {string} response.update    The type of update. 'core', 'plugin', 'theme', or 'translations'.
-	 * @param {string} response.reinstall Whether this was a reinstall request or not.
-	 * @param {string} response.error     The error that occurred.
-	 * @param {string} response.errorCode Error code for the error that occurred.
+	 * @param {object} response            Response from the server.
+	 * @param {string} response.update     The type of update. 'core', 'plugin', 'theme', or 'translations'.
+	 * @param {string} response.reinstall  Whether this was a reinstall request or not.
+	 * @param {string} response.error      The error that occurred.
+	 * @param {string} response.errorCode  Error code for the error that occurred.
+	 * @param {string} response.slug       Optional. Slug of the theme or plugin that was updated.
+	 * @param {string} response.plugin     Optional. Basename of the plugin that was updated.
+	 * @param {string} response.pluginName Optional. Name of the plugin that was updated.
 	 */
 	wp.updates.updateItemError = function( response ) {
 		var type = response.update,

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -1068,7 +1068,7 @@
 		$document.trigger( 'wp-' + type + '-update-success', response );
 
 		if ( 'core' === type && response.redirect ) {
-		//	window.location = response.redirect;
+			window.location = response.redirect;
 		}
 	};
 

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -180,15 +180,12 @@
 
 		if ( data.success ) {
 			options.success = data.success;
+			delete data.success;
 		}
 		if ( data.error ) {
 			options.error = data.error;
+			delete data.error;
 		}
-
-		// Do not send this data.
-		delete data.success;
-		delete data.error;
-		delete data.el;
 
 		options.data = _.extend( data, {
 			action:          action,
@@ -231,11 +228,10 @@
 	 * @param {string} upgradeType
 	 */
 	wp.updates.decrementCount = function( upgradeType ) {
-		var $menuItem, $itemCount,
-		    $adminBarUpdates             = $( '#wp-admin-bar-updates' ),
+		var $adminBarUpdates             = $( '#wp-admin-bar-updates' ),
 		    $dashboardNavMenuUpdateCount = $( 'a[href="update-core.php"] .update-plugins' ),
-		    count = $adminBarUpdates.find( '.ab-label' ).text(),
-		    itemCount;
+		    count                        = $adminBarUpdates.find( '.ab-label' ).text(),
+		    $menuItem, $itemCount, itemCount;
 
 		count = parseInt( count, 10 ) - 1;
 
@@ -579,7 +575,7 @@
 			    $views      = $( '.subsubsub' ),
 			    columnCount = $form.find( 'thead th:not(.hidden), thead td' ).length,
 			    plugins     = settings.plugins,
-				index;
+			    index;
 
 			$( this ).remove();
 
@@ -683,8 +679,9 @@
 
 			return wp.updates.ajax( 'update-theme', args );
 
-		 } else if ( 'themes-network' === pagenow ) {
+		} else if ( 'themes-network' === pagenow ) {
 			$notice = $( '[data-slug="' + args.slug + '"]' ).find( '.update-message' );
+
 		} else {
 			$notice = $( '#update-theme' ).closest( '.notice' );
 			if ( ! $notice.length ) {
@@ -1064,11 +1061,11 @@
 	 * Send an Ajax request to the server to install all available updates.
 	 *
 	 * @since 4.X.0
-	 * @param {jQuery}   $itemRow jQuery object of the item to be updated.
+	 * @param {jQuery} $itemRow jQuery object of the item to be updated.
 	 */
 	wp.updates.updateItem = function( $itemRow ) {
 		var type   = $itemRow.data( 'type' ),
-			update = {
+		    update = {
 				type: 'update-' + type,
 				data: {
 					success: wp.updates.updateItemSuccess,
@@ -1115,10 +1112,11 @@
 	 */
 	wp.updates.updateItemSuccess = function( response ) {
 		var type = response.update,
-			$row = $( '[data-type="' + type + '"]' );
+		    $row = $( '[data-type="' + type + '"]' );
 
 		if ( 'plugin' === type || 'theme' === type ) {
 			$row = $row.filter( '[data-slug="' + response.slug + '"]' );
+
 		} else if ( 'core' === type ) {
 			$row = $row.filter( function() {
 				return 'reinstall' === response.reinstall && $( this ).is( '.wordpress-reinstall-card' ) || 'reinstall' !== response.reinstall && ! $( this ).is( '.wordpress-reinstall-card' );
@@ -1160,8 +1158,8 @@
 	 */
 	wp.updates.updateItemError = function( response ) {
 		var type = response.update,
-			$row = $( '[data-type="' + type + '"]' ),
-			errorMessage = wp.updates.l10n.updateFailed.replace( '%s', response.error );
+		    $row = $( '[data-type="' + type + '"]' ),
+		    errorMessage = wp.updates.l10n.updateFailed.replace( '%s', response.error );
 
 		if ( response.errorCode && 'unable_to_connect_to_filesystem' === response.errorCode && wp.updates.shouldRequestFilesystemCredentials ) {
 			wp.updates.credentialError( response, 'update-core' );
@@ -1170,6 +1168,7 @@
 
 		if ( 'plugin' === type || 'theme' === type ) {
 			$row = $row.filter( '[data-slug="' + response.slug + '"]' );
+
 		} else if ( 'core' === type ) {
 			$row = $row.filter( function() {
 				return 'reinstall' === response.reinstall && $( this ).is( '.wordpress-reinstall-card' ) || 'reinstall' !== response.reinstall && ! $( this ).is( '.wordpress-reinstall-card' );
@@ -1306,9 +1305,9 @@
 	 */
 	wp.updates.requestForCredentialsModalOpen = function() {
 		var $modal = $( '#request-filesystem-credentials-dialog' );
+
 		$( 'body' ).addClass( 'modal-open' );
 		$modal.show();
-
 		$modal.find( 'input:enabled:first' ).focus();
 		$modal.on( 'keydown', wp.updates.keydown );
 	};
@@ -1331,7 +1330,7 @@
 	 * @since 4.X.0 Triggers an event for callbacks to listen to and add their actions.
 	 */
 	wp.updates.requestForCredentialsModalCancel = function() {
-		var plugin = wp.updates.updateQueue[ 0 ].data.plugin || {};
+		var plugin = wp.updates.updateQueue[ 0 ].data.plugin;
 
 		// No updateLock and no updateQueue means we already have cleared things up.
 		if ( false === wp.updates.updateLock && 0 === wp.updates.updateQueue.length ) {
@@ -1378,6 +1377,8 @@
 				 * Not cool that we're depending on response for this data.
 				 * This would feel more whole in a view all tied together.
 				 */
+				plugin: response.plugin,
+				slug:   response.slug
 			}
 		} );
 

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -1105,7 +1105,14 @@
 		$row.find( '.update-link' )
 			.removeClass( 'updating-message' )
 			.attr( 'aria-label', wp.updates.l10n.updateFailedShort )
+			.prop( 'disabled', true )
 			.text( wp.updates.l10n.updateFailedShort );
+
+		wp.updates.addAdminNotice( {
+			id:        response.errorCode,
+			className: 'notice-error is-dismissible',
+			message:   errorMessage
+		} );
 
 		wp.a11y.speak( errorMessage, 'assertive' );
 

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -1,4 +1,22 @@
-/*global pagenow */
+/* global pagenow, commonL10n */
+/**
+ *
+ * @param {jQuery}  $                                   jQuery object.
+ * @param {object}  wp                                  WP object.
+ * @param {object}  settings                            WP Updates settings.
+ * @param {string}  settings.ajax_nonce                 AJAX nonce.
+ * @param {object}  settings.l10n                       Translation strings.
+ * @param {?object} settings.plugins                    Base names of plugins in their different states.
+ * @param {Array}   settings.plugins.all                Base names of all plugins.
+ * @param {Array}   settings.plugins.active             Base names of active plugins.
+ * @param {Array}   settings.plugins.inactive           Base names of inactive plugins.
+ * @param {Array}   settings.plugins.upgrade            Base names of plugins with updates available.
+ * @param {Array}   settings.plugins.recently_activated Base names of recently activated plugins.
+ * @param {?object} settings.totals                     Plugin/theme status information or null.
+ * @param {number}  settings.totals.all                 Amount of all plugins or themes.
+ * @param {number}  settings.totals.upgrade             Amount of plugins or themes with updates available.
+ * @param {number}  settings.totals.disabled            Amount of disabled themes.
+ */
 (function( $, wp, settings ) {
 	var $document = $( document );
 
@@ -95,7 +113,7 @@
 	 *
 	 * @since 4.2.0
 	 *
-	 * @type {array}
+	 * @type {Array.object}
 	 */
 	wp.updates.updateQueue = [];
 
@@ -113,10 +131,14 @@
 	 *
 	 * @since 4.X.0
 	 *
-	 * @param {object} data
-	 * @param {string} data.id        Unique id that will be used as the notice's id attribute.
-	 * @param {string} data.className Class names that will be used in the admin notice.
-	 * @param {string} data.message   The message displayed in the notice.
+	 * @param {object}  data
+	 * @param {string}  data.id            Unique id that will be used as the notice's id attribute.
+	 * @param {string=} data.className     Optional. Class names that will be used in the admin notice.
+	 * @param {string=} data.message       OptionalThe message displayed in the notice.
+	 * @param {number=} data.successes     Optional. The amount of successful operations.
+	 * @param {number=} data.errors        Optional. The amount of failed operations.
+	 * @param {Array=}  data.errorMessages Optional. Error messages of failed operations.
+	 *
 	 */
 	wp.updates.addAdminNotice = function( data ) {
 		var $notices     = $( '.wrap' ),
@@ -187,8 +209,8 @@
 	 *
 	 * @since 4.X.0
 	 *
-	 * @param {object} response
-	 * @param {array}  response.debug Debug inforamation. Optional.
+	 * @param {object}  response
+	 * @param {array=}  response.debug Optional. Debug information.
 	 */
 	wp.updates.ajaxAlways = function( response ) {
 		wp.updates.updateLock = false;
@@ -315,7 +337,7 @@
 	 *
 	 * @since 4.2.0
 	 *
-	 * @callback updateSuccess
+	 * @typedef {object} updateSuccess
 	 * @param {object} response            Response from the server.
 	 * @param {string} response.slug       Slug of the plugin to be updated.
 	 * @param {string} response.plugin     Basename of the plugin to be updated.
@@ -354,7 +376,7 @@
 	 *
 	 * @since 4.2.0
 	 *
-	 * @callback updateError
+	 * @typedef {object} updateError
 	 * @param {object} response            Response from the server.
 	 * @param {string} response.slug       Slug of the plugin to be updated.
 	 * @param {string} response.plugin     Basename of the plugin to be updated.
@@ -413,11 +435,10 @@
 	 *
 	 * @since 4.X.0
 	 *
-	 * @param {object}               args         Arguments.
-	 * @param {string}               args.plugin  Plugin basename.
-	 * @param {string}               args.slug    Plugin identifier in the WordPress.org Plugin repository.
-	 * @param {installPluginSuccess} args.success Success callback.
-	 * @param {installPluginError}   args.error   Error callback.
+	 * @param {object}                args         Arguments.
+	 * @param {string}                args.slug    Plugin identifier in the WordPress.org Plugin repository.
+	 * @param {installPluginSuccess=} args.success Optional. Success callback.
+	 * @param {installPluginError=}   args.error   Optional. Error callback.
 	 * @return {$.promise} A jQuery promise that represents the request,
 	 *                     decorated with an abort() method.
 	 */
@@ -440,7 +461,7 @@
 	 *
 	 * @since 4.X.0
 	 *
-	 * @callback installPluginSuccess
+	 * @typedef {object} installPluginSuccess
 	 * @param {object} response             Response from the server.
 	 * @param {string} response.slug        Slug of the plugin to be installed.
 	 * @param {string} response.activateUrl URL to activate the just installed plugin.
@@ -471,7 +492,7 @@
 	 *
 	 * @since 4.X.0
 	 *
-	 * @callback installPluginError
+	 * @typedef {object} installPluginError
 	 * @param {object} response            Response from the server.
 	 * @param {string} response.slug       Slug of the plugin to be installed.
 	 * @param {string} response.plugin     Basename of the plugin to be installed.
@@ -522,8 +543,8 @@
 	 * @param {object}              args         Arguments.
 	 * @param {string}              args.plugin  Plugin basename.
 	 * @param {string}              args.slug    Plugin slug.
-	 * @param {deletePluginSuccess} args.success Success callback.
-	 * @param {deletePluginError}   args.error   Error callback.
+	 * @param {deletePluginSuccess=} args.success Success callback.
+	 * @param {deletePluginError=}   args.error   Error callback.
 	 * @return {$.promise} A jQuery promise that represents the request,
 	 *                     decorated with an abort() method.
 	 */
@@ -538,7 +559,7 @@
 	 *
 	 * @since 4.X.0
 	 *
-	 * @callback deletePluginSuccess
+	 * @typedef {object} deletePluginSuccess
 	 * @param {object} response        Response from the server.
 	 * @param {string} response.slug   Slug of the plugin to be deleted.
 	 * @param {string} response.plugin Basename of the plugin to be deleted.
@@ -550,19 +571,20 @@
 			var $form       = $( '#bulk-action-form' ),
 			    $views      = $( '.subsubsub' ),
 			    columnCount = $form.find( 'thead th:not(.hidden), thead td' ).length,
-			    plugins     = settings.plugins;
+			    plugins     = settings.plugins,
+				index;
 
 			$( this ).remove();
 
 			// Remove plugin from update count.
-			if ( -1 !== plugins.upgrade.indexOf( response.plugin ) ) {
-				plugins.upgrade = _.without( plugins.upgrade, response.plugin );
+			if ( -1 !== ( index = plugins.upgrade.indexOf( response.plugin ) ) ) {
+				delete plugins.upgrade[ index ];
 				wp.updates.decrementCount( 'plugin' );
 			}
 
 			// Remove from views.
-			if ( -1 !== plugins.inactive.indexOf( response.plugin ) ) {
-				plugins.inactive = _.without( plugins.inactive, response.plugin );
+			if ( -1 !== ( index = plugins.inactive.indexOf( response.plugin ) ) ) {
+				delete plugins.inactive[ index ];
 				if ( plugins.inactive.length > 0 ) {
 					$views.find( '.inactive .count' ).text( '(' + plugins.inactive.length + ')' );
 				} else {
@@ -570,8 +592,8 @@
 				}
 			}
 
-			if ( -1 !== plugins.active.indexOf( response.plugin ) ) {
-				plugins.active = _.without( plugins.active, response.plugin );
+			if ( -1 !== ( index = plugins.active.indexOf( response.plugin ) ) ) {
+				delete plugins.active[ index ];
 				if ( plugins.active.length ) {
 					$views.find( '.active .count' ).text( '(' + plugins.active.length + ')' );
 				} else {
@@ -579,8 +601,8 @@
 				}
 			}
 
-			if ( -1 !== plugins.recently_activated.indexOf( response.plugin ) ) {
-				plugins.recently_activated = _.without( plugins.recently_activated, response.plugin );
+			if ( -1 !== ( index = plugins.recently_activated.indexOf( response.plugin ) ) ) {
+				delete plugins.recently_activated[ index ];
 				if ( plugins.recently_activated.length ) {
 					$views.find( '.recently_activated .count' ).text( '(' + plugins.recently_activated.length + ')' );
 				} else {
@@ -588,7 +610,8 @@
 				}
 			}
 
-			plugins.all = _.without( plugins.all, response.plugin );
+			index = plugins.all.indexOf( response.plugin );
+			delete plugins.all[ index ];
 			if ( plugins.all.length ) {
 				$views.find( '.all .count' ).text( '(' + plugins.all.length + ')' );
 			} else {
@@ -610,7 +633,7 @@
 	 *
 	 * @since 4.X.0
 	 *
-	 * @callback deletePluginError
+	 * @typedef {object} deletePluginError
 	 * @param {object} response           Response from the server.
 	 * @param {string} response.plugin    Basename of the plugin to be deleted.
 	 * @param {string} response.error     The error that occurred.
@@ -681,7 +704,7 @@
 	 *
 	 * @since 4.X.0
 	 *
-	 * @callback updateThemeSuccess
+	 * @typedef {object} updateThemeSuccess
 	 * @param {object} response
 	 * @param {string} response.slug       Slug of the theme to be updated.
 	 * @param {object} response.theme      Updated theme.
@@ -735,7 +758,7 @@
 	 *
 	 * @since 4.X.0
 	 *
-	 * @callback updateThemeError
+	 * @typedef {object} updateThemeError
 	 * @param {object} response           Response from the server.
 	 * @param {string} response.slug      Slug of the theme to be updated.
 	 * @param {string} response.error     The error that occurred.
@@ -805,7 +828,7 @@
 	 *
 	 * @since 4.X.0
 	 *
-	 * @callback installThemeSuccess
+	 * @typedef {object} installThemeSuccess
 	 * @param {object} response      Response from the server.
 	 * @param {string} response.slug Slug of the theme to be installed.
 	 */
@@ -826,7 +849,7 @@
 	 *
 	 * @since 4.X.0
 	 *
-	 * @callback installThemeError
+	 * @typedef {object} installThemeError
 	 * @param {object} response           Response from the server.
 	 * @param {string} response.slug      Slug of the theme to be installed.
 	 * @param {string} response.error     The error that occurred.
@@ -895,7 +918,7 @@
 	 *
 	 * @since 4.X.0
 	 *
-	 * @callback deleteThemeSuccess
+	 * @typedef {object} deleteThemeSuccess
 	 * @param {object} response      Response from the server.
 	 * @param {string} response.slug Slug of the theme to be deleted.
 	 */
@@ -913,7 +936,7 @@
 
 				// Remove plugin from update count.
 				if ( $themeRow.hasClass( 'update' ) ) {
-					totals.upgrades--;
+					totals.upgrade--;
 					wp.updates.decrementCount( 'theme' );
 				}
 
@@ -942,7 +965,7 @@
 	 *
 	 * @since 4.X.0
 	 *
-	 * @callback deleteThemeError
+	 * @typedef {object} deleteThemeError
 	 * @param {object} response           Response from the server.
 	 * @param {string} response.slug      Slug of the theme to be deleted.
 	 * @param {string} response.error     The error that occurred.
@@ -978,11 +1001,12 @@
 	 *
 	 * @since 4.X.0
 	 *
-	 * @param {object}            args           Arguments.
-	 * @param {string}            args.type      Type of update. 'core' or 'translations'.
-	 * @param {updateItemSuccess} args.success   Success callback.
-	 * @param {updateItemError}   args.error     Error callback.
-	 * @param {jQuery}            args.reinstall Whether this is a reinstall request or not.
+	 * @param {object}             args           Arguments.
+	 * @param {string}             args.version   The version to update to.
+	 * @param {string}             args.locale    The locale to get the update for.
+	 * @param {boolean}            args.reinstall Whether this is a reinstall request or not.
+	 * @param {updateItemSuccess=} args.success   Optional. Success callback.
+	 * @param {updateItemError=}   args.error     Optional. Error callback.
 	 * @return {$.promise} A jQuery promise that represents the request,
 	 *                     decorated with an abort() method.
 	 */
@@ -1009,11 +1033,9 @@
 	 *
 	 * @since 4.X.0
 	 *
-	 * @param {object}            args         Arguments.
-	 * @param {string}            args.type    Type of update. 'core' or 'translations'.
-	 * @param {updateItemSuccess} args.success Success callback.
-	 * @param {updateItemError}   args.error   Error callback.
-	 * @param {jQuery}            args.el      The list table row
+	 * @param {object}             args         Arguments.
+	 * @param {updateItemSuccess=} args.success Optional. Success callback.
+	 * @param {updateItemError=}   args.error   Optional. Error callback.
 	 * @return {$.promise} A jQuery promise that represents the request,
 	 *                     decorated with an abort() method.
 	 */
@@ -1029,102 +1051,6 @@
 			.text( wp.updates.l10n.updating );
 
 		return wp.updates.ajax( 'update-translations', args );
-	};
-
-	/**
-	 * On a successful core update, update the UI appropriately and redirect to the about page.
-	 *
-	 * @since 4.X.0
-	 *
-	 * @callback updateItemSuccess
-	 * @param {object} response            Response from the server.
-	 * @param {string} response.update     The type of update. 'core', 'plugin', 'theme', or 'translations'.
-	 * @param {string} response.slug       Optional. Slug of the theme or plugin that was updated.
-	 * @param {string} response.reinstall  Optional. Whether this was a reinstall request or not.
-	 * @param {string} response.redirect   Optional. URL to redirect to after updating Core.
-	 * @param {string} response.plugin     Optional. Basename of the plugin that was updated.
-	 * @param {string} response.pluginName Optional. Name of the plugin that was updated.
-	 * @param {string} response.oldVersion Optional. Old version of the theme or plugin.
-	 * @param {string} response.newVersion Optional. New version of the theme or plugin.
-	 */
-	wp.updates.updateItemSuccess = function( response ) {
-		var type = response.update,
-			$row = $( '[data-type="' + type + '"]' );
-
-		if ( 'plugin' === type || 'theme' === type ) {
-			$row = $row.filter( '[data-slug="' + response.slug + '"]' );
-		} else if ( 'core' === type ) {
-			$row = $row.filter( function() {
-				return 'reinstall' === response.reinstall && $( this ).is( '.wordpress-reinstall-card' ) || 'reinstall' !== response.reinstall && ! $( this ).is( '.wordpress-reinstall-card' );
-			} );
-		}
-
-		$row.find( '.update-link' )
-			.removeClass( 'updating-message' )
-			.addClass( 'updated-message' )
-			.attr( 'aria-label', wp.updates.l10n.updated )
-			.prop( 'disabled', true )
-			.text( wp.updates.l10n.updated );
-
-		wp.a11y.speak( wp.updates.l10n.updatedMsg, 'polite' );
-
-		wp.updates.decrementCount( type );
-
-		$document.trigger( 'wp-' + type + '-update-success', response );
-
-		if ( 'core' === type && response.redirect ) {
-			window.location = response.redirect;
-		}
-	};
-
-	/**
-	 * On a core update error, update the UI appropriately.
-	 *
-	 * @since 4.X.0
-	 *
-	 * @callback updateItemError
-	 * @param {object} response            Response from the server.
-	 * @param {string} response.update     The type of update. 'core', 'plugin', 'theme', or 'translations'.
-	 * @param {string} response.reinstall  Whether this was a reinstall request or not.
-	 * @param {string} response.error      The error that occurred.
-	 * @param {string} response.errorCode  Error code for the error that occurred.
-	 * @param {string} response.slug       Optional. Slug of the theme or plugin that was updated.
-	 * @param {string} response.plugin     Optional. Basename of the plugin that was updated.
-	 * @param {string} response.pluginName Optional. Name of the plugin that was updated.
-	 */
-	wp.updates.updateItemError = function( response ) {
-		var type = response.update,
-			$row = $( '[data-type="' + type + '"]' ),
-			errorMessage = wp.updates.l10n.updateFailed.replace( '%s', response.error );
-
-		if ( response.errorCode && 'unable_to_connect_to_filesystem' === response.errorCode && wp.updates.shouldRequestFilesystemCredentials ) {
-			wp.updates.credentialError( response, 'update-core' );
-			return;
-		}
-
-		if ( 'plugin' === type || 'theme' === type ) {
-			$row = $row.filter( '[data-slug="' + response.slug + '"]' );
-		} else if ( 'core' === type ) {
-			$row = $row.filter( function() {
-				return 'reinstall' === response.reinstall && $( this ).is( '.wordpress-reinstall-card' ) || 'reinstall' !== response.reinstall && ! $( this ).is( '.wordpress-reinstall-card' );
-			} );
-		}
-
-		$row.find( '.update-link' )
-			.removeClass( 'updating-message' )
-			.attr( 'aria-label', wp.updates.l10n.updateFailedShort )
-			.prop( 'disabled', true )
-			.text( wp.updates.l10n.updateFailedShort );
-
-		wp.updates.addAdminNotice( {
-			id:        response.errorCode,
-			className: 'notice-error is-dismissible',
-			message:   errorMessage
-		} );
-
-		wp.a11y.speak( errorMessage, 'assertive' );
-
-		$document.trigger( 'wp-' + type + '-update-error', response );
 	};
 
 	/**
@@ -1162,6 +1088,102 @@
 
 		wp.updates.updateQueue.push( update );
 		wp.updates.queueChecker();
+	};
+
+	/**
+	 * On a successful core update, update the UI appropriately and redirect to the about page.
+	 *
+	 * @since 4.X.0
+	 *
+	 * @typedef {object} updateItemSuccess
+	 * @param {object}  response            Response from the server.
+	 * @param {string}  response.update     The type of update. 'core', 'plugin', 'theme', or 'translations'.
+	 * @param {string=} response.slug       Optional. Slug of the theme or plugin that was updated.
+	 * @param {string=} response.reinstall  Optional. Whether this was a reinstall request or not.
+	 * @param {string=} response.redirect   Optional. URL to redirect to after updating Core.
+	 * @param {string=} response.plugin     Optional. Basename of the plugin that was updated.
+	 * @param {string=} response.pluginName Optional. Name of the plugin that was updated.
+	 * @param {string=} response.oldVersion Optional. Old version of the theme or plugin.
+	 * @param {string=} response.newVersion Optional. New version of the theme or plugin.
+	 */
+	wp.updates.updateItemSuccess = function( response ) {
+		var type = response.update,
+			$row = $( '[data-type="' + type + '"]' );
+
+		if ( 'plugin' === type || 'theme' === type ) {
+			$row = $row.filter( '[data-slug="' + response.slug + '"]' );
+		} else if ( 'core' === type ) {
+			$row = $row.filter( function() {
+				return 'reinstall' === response.reinstall && $( this ).is( '.wordpress-reinstall-card' ) || 'reinstall' !== response.reinstall && ! $( this ).is( '.wordpress-reinstall-card' );
+			} );
+		}
+
+		$row.find( '.update-link' )
+			.removeClass( 'updating-message' )
+			.addClass( 'updated-message' )
+			.attr( 'aria-label', wp.updates.l10n.updated )
+			.prop( 'disabled', true )
+			.text( wp.updates.l10n.updated );
+
+		wp.a11y.speak( wp.updates.l10n.updatedMsg, 'polite' );
+
+		wp.updates.decrementCount( type );
+
+		$document.trigger( 'wp-' + type + '-update-success', response );
+
+		if ( 'core' === type && response.redirect ) {
+			window.location = response.redirect;
+		}
+	};
+
+	/**
+	 * On a core update error, update the UI appropriately.
+	 *
+	 * @since 4.X.0
+	 *
+	 * @typedef {object} updateItemError
+	 * @param {object}  response            Response from the server.
+	 * @param {string}  response.update     The type of update. 'core', 'plugin', 'theme', or 'translations'.
+	 * @param {string}  response.error      The error that occurred.
+	 * @param {string}  response.errorCode  Error code for the error that occurred.
+	 * @param {string=} response.slug       Optional. Slug of the theme or plugin that was updated.
+	 * @param {string=} response.plugin     Optional. Basename of the plugin that was updated.
+	 * @param {string=} response.pluginName Optional. Name of the plugin that was updated.
+	 * @param {string=} response.reinstall  Optional. Whether this was a reinstall request or not.
+	 */
+	wp.updates.updateItemError = function( response ) {
+		var type = response.update,
+			$row = $( '[data-type="' + type + '"]' ),
+			errorMessage = wp.updates.l10n.updateFailed.replace( '%s', response.error );
+
+		if ( response.errorCode && 'unable_to_connect_to_filesystem' === response.errorCode && wp.updates.shouldRequestFilesystemCredentials ) {
+			wp.updates.credentialError( response, 'update-core' );
+			return;
+		}
+
+		if ( 'plugin' === type || 'theme' === type ) {
+			$row = $row.filter( '[data-slug="' + response.slug + '"]' );
+		} else if ( 'core' === type ) {
+			$row = $row.filter( function() {
+				return 'reinstall' === response.reinstall && $( this ).is( '.wordpress-reinstall-card' ) || 'reinstall' !== response.reinstall && ! $( this ).is( '.wordpress-reinstall-card' );
+			} );
+		}
+
+		$row.find( '.update-link' )
+			.removeClass( 'updating-message' )
+			.attr( 'aria-label', wp.updates.l10n.updateFailedShort )
+			.prop( 'disabled', true )
+			.text( wp.updates.l10n.updateFailedShort );
+
+		wp.updates.addAdminNotice( {
+			id:        response.errorCode,
+			className: 'notice-error is-dismissible',
+			message:   errorMessage
+		} );
+
+		wp.a11y.speak( errorMessage, 'assertive' );
+
+		$document.trigger( 'wp-' + type + '-update-error', response );
 	};
 
 	/**
@@ -1214,7 +1236,7 @@
 				break;
 
 			default:
-				window.console.log( 'Failed to execute queued update job.', job );
+				window.console.error( 'Failed to execute queued update job.', job );
 				break;
 		}
 	};
@@ -1224,7 +1246,7 @@
 	 *
 	 * @since 4.2.0
 	 *
-	 * @param {Event} event Event interface.
+	 * @param {Event=} event Optional. Event interface.
 	 */
 	wp.updates.requestFilesystemCredentials = function( event ) {
 		if ( false === wp.updates.filesystemCredentials.available ) {
@@ -1302,7 +1324,7 @@
 	 * @since 4.X.0 Triggers an event for callbacks to listen to and add their actions.
 	 */
 	wp.updates.requestForCredentialsModalCancel = function() {
-		var plugin = wp.updates.updateQueue[ 0 ].data.plugin;
+		var plugin = wp.updates.updateQueue[ 0 ].data.plugin || {};
 
 		// No updateLock and no updateQueue means we already have cleared things up.
 		if ( false === wp.updates.updateLock && 0 === wp.updates.updateQueue.length ) {
@@ -1349,8 +1371,6 @@
 				 * Not cool that we're depending on response for this data.
 				 * This would feel more whole in a view all tied together.
 				 */
-				plugin: response.plugin,
-				slug:   response.slug
 			}
 		} );
 
@@ -1635,6 +1655,7 @@
 					break;
 
 				default:
+					window.console.error( 'Failed to identify bulk action: %s', action );
 					return;
 			}
 
@@ -1739,6 +1760,7 @@
 					break;
 
 				default:
+					window.console.error( 'Failed to identify bulk action: %s', action );
 					return;
 			}
 
@@ -1821,20 +1843,20 @@
 			}
 
 			$message.attr( 'aria-label', wp.updates.l10n.updatingMsg ).text( wp.updates.l10n.updating );
-			
+
 			$document.on( 'wp-plugin-update-success wp-theme-update-success wp-core-update-success wp-translations-update-success wp-plugin-update-error wp-theme-update-error wp-core-update-error wp-translations-update-error ', function() {
 				if ( 0 === wp.updates.updateQueue.length ) {
 					$message
 						.removeClass( 'updating-message' )
 						.attr( 'aria-label', wp.updates.l10n.updated )
 						.prop( 'disabled', true )
-						.text( wp.updates.l10n.updated )
+						.text( wp.updates.l10n.updated );
 				}
 			} );
 
 			// Translations first, themes and plugins afterwards before updating core at last.
 			$( $( 'tr[data-type]', '#wp-updates-table' ).get().reverse() ).each( function( index, element ) {
-				var $itemRow = $( element )
+				var $itemRow = $( element );
 
 				if ( $( '.update-link', $itemRow ).prop( 'disabled' ) ) {
 					return;
@@ -1877,7 +1899,8 @@
 			$( '.notice.is-dismissible' ).each( function() {
 				var $notice = $( this ),
 				    $button = $( '<button type="button" class="notice-dismiss"><span class="screen-reader-text"></span></button>' ),
-				    btnText = window.commonL10n.dismiss || '';
+				    /** @property {string} commonL10n.dismiss Dismiss message. */
+				    btnText = commonL10n.dismiss || '';
 
 				// Ensure plain text.
 				$button.find( '.screen-reader-text' ).text( btnText );
@@ -1976,7 +1999,7 @@
 		 */
 		$( '#plugin_update_from_iframe' ).on( 'click', function( event ) {
 			var target = window.parent === window ? null : window.parent,
-			    job;
+			    update;
 
 			$.support.postMessage = !! window.postMessage;
 
@@ -1986,7 +2009,7 @@
 
 			event.preventDefault();
 
-			job = {
+			update = {
 				action: 'updatePlugin',
 				type:   'update-plugin',
 				data:   {
@@ -1995,7 +2018,7 @@
 				}
 			};
 
-			target.postMessage( JSON.stringify( job ), window.location.origin );
+			target.postMessage( JSON.stringify( update ), window.location.origin );
 		} );
 
 		/**
@@ -2007,7 +2030,7 @@
 		 */
 		$( '#plugin_install_from_iframe' ).on( 'click', function( event ) {
 			var target = window.parent === window ? null : window.parent,
-			    job;
+				install;
 
 			$.support.postMessage = !! window.postMessage;
 
@@ -2017,7 +2040,7 @@
 
 			event.preventDefault();
 
-			job = {
+			install = {
 				action: 'installPlugin',
 				type:   'install-plugin',
 				data:   {
@@ -2025,7 +2048,7 @@
 				}
 			};
 
-			target.postMessage( JSON.stringify( job ), window.location.origin );
+			target.postMessage( JSON.stringify( install ), window.location.origin );
 		} );
 
 		/**
@@ -2057,6 +2080,7 @@
 				 * @todo Check if that can be removed once this plugin was merged.
 				 */
 				case 'decrementUpdateCount':
+					/** @property {string} message.upgradeType */
 					wp.updates.decrementCount( message.upgradeType );
 					break;
 

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -6,13 +6,13 @@
  * @param {object}  settings                            WP Updates settings.
  * @param {string}  settings.ajax_nonce                 AJAX nonce.
  * @param {object}  settings.l10n                       Translation strings.
- * @param {?object} settings.plugins                    Base names of plugins in their different states.
+ * @param {object=} settings.plugins                    Base names of plugins in their different states.
  * @param {Array}   settings.plugins.all                Base names of all plugins.
  * @param {Array}   settings.plugins.active             Base names of active plugins.
  * @param {Array}   settings.plugins.inactive           Base names of inactive plugins.
  * @param {Array}   settings.plugins.upgrade            Base names of plugins with updates available.
  * @param {Array}   settings.plugins.recently_activated Base names of recently activated plugins.
- * @param {?object} settings.totals                     Plugin/theme status information or null.
+ * @param {object=} settings.totals                     Plugin/theme status information or null.
  * @param {number}  settings.totals.all                 Amount of all plugins or themes.
  * @param {number}  settings.totals.upgrade             Amount of plugins or themes with updates available.
  * @param {number}  settings.totals.disabled            Amount of disabled themes.
@@ -24,6 +24,8 @@
 
 	/**
 	 * The WP Updates object.
+	 *
+	 * @since 4.2.0
 	 *
 	 * @type {object}
 	 */
@@ -307,7 +309,6 @@
 			$updateRow = $( 'tr[data-plugin="' + args.plugin + '"]' );
 			$message   = $updateRow.find( '.update-message' ).addClass( 'updating-message' ).find( 'p' );
 			message    = wp.updates.l10n.updatingLabel.replace( '%s', $updateRow.find( '.plugin-title strong' ).text() );
-
 		} else if ( 'plugin-install' === pagenow || 'plugin-install-network' === pagenow ) {
 			$card    = $( '.plugin-card-' + args.slug );
 			$message = $card.find( '.update-now' ).addClass( 'updating-message' );
@@ -315,7 +316,6 @@
 
 			// Remove previous error messages, if any.
 			$card.removeClass( 'plugin-card-update-failed' ).find( '.notice.notice-error' ).remove();
-
 		} else if ( 'update-core' === pagenow ) {
 			$message = $( '.update-link[data-plugin="' + args.plugin + '"]' ).addClass( 'updating-message' );
 			message  = wp.updates.l10n.updatingLabel.replace( '%s', $message.data( 'name' ) );
@@ -327,6 +327,7 @@
 			if ( $message.html() !== wp.updates.l10n.updating ) {
 				$message.data( 'originaltext', $message.html() );
 			}
+
 			$message.text( wp.updates.l10n.updating );
 
 			$document.trigger( 'wp-plugin-updating' );
@@ -400,7 +401,6 @@
 		if ( 'plugins' === pagenow || 'plugins-network' === pagenow ) {
 			$message = $( 'tr[data-plugin="' + response.plugin + '"]' ).find( '.update-message' );
 			$message.removeClass( 'updating-message notice-warning' ).addClass( 'notice-error' ).find( 'p' ).html( errorMessage );
-
 		} else if ( 'plugin-install' === pagenow || 'plugin-install-network' === pagenow ) {
 			$card = $( '.plugin-card-' + response.slug )
 				.addClass( 'plugin-card-update-failed' )
@@ -1116,10 +1116,10 @@
 
 		if ( 'plugin' === type || 'theme' === type ) {
 			$row = $row.filter( '[data-slug="' + response.slug + '"]' );
-
 		} else if ( 'core' === type ) {
 			$row = $row.filter( function() {
-				return 'reinstall' === response.reinstall && $( this ).is( '.wordpress-reinstall-card' ) || 'reinstall' !== response.reinstall && ! $( this ).is( '.wordpress-reinstall-card' );
+				return 'reinstall' === response.reinstall && $( this ).is( '.wordpress-reinstall-card' ) ||
+					'reinstall' !== response.reinstall && ! $( this ).is( '.wordpress-reinstall-card' );
 			} );
 		}
 
@@ -1168,10 +1168,10 @@
 
 		if ( 'plugin' === type || 'theme' === type ) {
 			$row = $row.filter( '[data-slug="' + response.slug + '"]' );
-
 		} else if ( 'core' === type ) {
 			$row = $row.filter( function() {
-				return 'reinstall' === response.reinstall && $( this ).is( '.wordpress-reinstall-card' ) || 'reinstall' !== response.reinstall && ! $( this ).is( '.wordpress-reinstall-card' );
+				return 'reinstall' === response.reinstall && $( this ).is( '.wordpress-reinstall-card' ) ||
+					'reinstall' !== response.reinstall && ! $( this ).is( '.wordpress-reinstall-card' );
 			} );
 		}
 
@@ -1256,7 +1256,6 @@
 	 */
 	wp.updates.requestFilesystemCredentials = function( event ) {
 		if ( false === wp.updates.filesystemCredentials.available ) {
-
 			/*
 			 * After exiting the credentials request modal,
 			 * return the focus to the element triggering the request.
@@ -1550,6 +1549,7 @@
 		 */
 		$theList.on( 'click', '[data-plugin] a.delete', function( event ) {
 			var $pluginRow = $( event.target ).parents( 'tr' );
+
 			event.preventDefault();
 
 			if ( ! window.confirm( wp.updates.l10n.aysDelete.replace( '%s', $pluginRow.find( '.plugin-title strong' ).text() ) ) ) {
@@ -1578,6 +1578,7 @@
 		 */
 		$document.on( 'click', '.themes-php.network-admin .update-link', function( event ) {
 			var $themeRow = $( event.target ).parents( 'tr' );
+
 			event.preventDefault();
 
 			if ( wp.updates.shouldRequestFilesystemCredentials && ! wp.updates.updateLock ) {
@@ -1602,6 +1603,7 @@
 		 */
 		$document.on( 'click', '.themes-php.network-admin a.delete', function( event ) {
 			var $themeRow = $( event.target ).parents( 'tr' );
+
 			event.preventDefault();
 
 			if ( ! window.confirm( wp.updates.l10n.aysDelete.replace( '%s', $themeRow.find( '.plugin-title strong' ).text() ) ) ) {
@@ -1897,6 +1899,7 @@
 
 			$message.removeClass( 'updating-message' );
 			$message.html( $message.data( 'originaltext' ) );
+
 			wp.a11y.speak( wp.updates.l10n.updateCancel, 'polite' );
 		} );
 

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -1542,30 +1542,6 @@
 		} );
 
 		/**
-		 * Click handler for theme updates in List Table view.
-		 *
-		 * @since 4.2.0
-		 *
-		 * @param {Event} event Event interface.
-		 */
-		$theList.on( 'click', '[data-type="theme"] .update-link', function( event ) {
-			var $themeRow = $( event.target ).parents( 'tr' );
-			event.preventDefault();
-
-			if ( wp.updates.shouldRequestFilesystemCredentials && ! wp.updates.updateLock ) {
-				wp.updates.requestFilesystemCredentials( event );
-			}
-
-			// Return the user to the input box of the theme's table row after closing the modal.
-			wp.updates.$elToReturnFocusToFromCredentialsModal = $themeRow.find( '.check-column input' );
-			wp.updates.updateTheme( {
-				slug:    $themeRow.data( 'slug' ),
-				success: wp.updates.updateThemeSuccess,
-				error:   wp.updates.updateThemeError
-			} );
-		} );
-
-		/**
 		 * Update a theme.
 		 *
 		 * @since 4.X.0


### PR DESCRIPTION
Refactors `updateItem` to be more of a distributor of update requests, and `updateAll` to use `updateItem` for each update.

Fixes #157 thanks to 38cdb1bc51e6b40db2a19d7520b72633b5435ddd.