### PR TITLE
Remove `updateLock` check and defer to `wp.ajax` to do the throttling.

### DIFF
--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -1201,7 +1201,7 @@
 	wp.updates.queueChecker = function() {
 		var job;
 
-		if ( wp.updates.updateLock || wp.updates.updateQueue.length <= 0 ) {
+		if ( wp.updates.updateQueue.length <= 0 ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #183.