### PR TITLE
Make selector population more explicit.

### DIFF
--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -686,7 +686,10 @@
 		if ( 'themes-network' === pagenow ) {
 			$notice = $( '[data-slug="' + args.slug + '"]' ).find( '.update-message' );
 		} else {
-			$notice = $( '#update-theme' ).closest( '.notice' ) || $( '[data-slug="' + args.slug + '"]' ).find( '.update-message' );
+			$notice = $( '#update-theme' ).closest( '.notice' );
+			if ( ! $notice.length ) {
+				$notice = $( '[data-slug="' + args.slug + '"]' ).find( '.update-message' );
+			}
 		}
 
 		message = $notice.find( 'p' ).text();


### PR DESCRIPTION
Even if jQuery can’t find a `.notice` within `#update-theme`, it still
returns a jQuery object, hence we never get to the fallback selector.

Fixes #192.