### PR TITLE
Add "View Details" link for themes on Dashboard -> Updates

### DIFF
--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -289,6 +289,20 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	public function column_title_theme( $item ) {
 		/* @var WP_Theme $theme */
 		$theme = $item['data'];
+
+		$details_url = add_query_arg( array(
+			'TB_iframe' => 'true',
+			'width'     => 1024,
+			'height'    => 800,
+			'test' => 'abc',
+		), $theme->update['url'] );
+
+		/* translators: 1: theme name, 2: escaped theme name, 3: version number */
+		$details = sprintf( __( '<a href="%1$s" class="thickbox open-plugin-details-modal" aria-label="View %2$s version %3$s details">View version %3$s details</a>.' ),
+			esc_url( $details_url ),
+			esc_attr( $theme['Name'] ),
+			$theme->update['new_version']
+		);
 		?>
 		<div class="updates-table-screenshot">
 			<img src="<?php echo esc_url( $theme->get_screenshot() ); ?>" width="85" height="64" alt=""/>
@@ -301,6 +315,8 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 				$theme->display( 'Version' ),
 				$theme->update['new_version']
 			);
+
+			echo ' ' . $details;
 			?>
 		</p>
 		<?php

--- a/src/functions.php
+++ b/src/functions.php
@@ -351,11 +351,23 @@ function su_theme_data( $themes ) {
 	$update = get_site_transient( 'update_themes' );
 	foreach ( $themes as $stylesheet => $theme ) {
 		if ( isset( $theme['hasUpdate'] ) && $theme['hasUpdate'] && current_user_can( 'update_themes' ) && ! empty( $update->response[ $stylesheet ] ) ) {
-			$themes[ $stylesheet ]['update'] = sprintf( '<p><strong>' . __( 'There is a new version of %1$s available. <a href="%2$s" class="thickbox open-plugin-details-modal" title="%3$s">View version %4$s details</a> or <a id="update-theme" data-slug="%5$s" href="%6$s">update now</a>.' ) . '</strong></p>', $theme['name'], esc_url( add_query_arg( array(
-				'TB_iframe' => 'true',
-				'width'     => 1024,
-				'height'    => 800,
-			), $update->response[ $stylesheet ]['url'] ) ), esc_attr( $theme['name'] ), $update->response[ $stylesheet ]['new_version'], $stylesheet, wp_nonce_url( admin_url( 'update.php?action=upgrade-theme&amp;theme=' . urlencode( $stylesheet ) ), 'upgrade-theme_' . $stylesheet ) );
+			$themes[ $stylesheet ]['update'] = sprintf(
+				/* translators: 1: theme name, 2: details URL, 3: escaped theme name, 4: version number, 5: theme slug, 6: update URL */
+				'<p><strong>' . __( 'There is a new version of %1$s available. <a href="%2$s" class="thickbox open-plugin-details-modal" title="%3$s" aria-label="View %3$s version %4$s details">View version %4$s details</a> or <a id="update-theme" data-slug="%5$s" href="%6$s">update now</a>.' ) . '</strong></p>',
+				$theme['name'],
+				esc_url( add_query_arg(
+					array(
+						'TB_iframe' => 'true',
+						'width'     => 1024,
+						'height'    => 800,
+					),
+					$update->response[ $stylesheet ]['url']
+				) ),
+				esc_attr( $theme['name'] ),
+				$update->response[ $stylesheet ]['new_version'],
+				$stylesheet,
+				wp_nonce_url( admin_url( 'update.php?action=upgrade-theme&amp;theme=' . urlencode( $stylesheet ) ), 'upgrade-theme_' . $stylesheet )
+			);
 		}
 	}
 


### PR DESCRIPTION
Unfortunately I have no idea why the modal so narrow:

<img width="1437" alt="screen shot 2016-06-02 at 19 14 59" src="https://cloud.githubusercontent.com/assets/841956/15755756/850b4fde-28fe-11e6-8d3d-5b3255c5e3f9.png">

Other scripts like `plugin-install.js` or `theme.js` do some JS trickery to improve keyboard navigation for Thickbox and resize it on window resize. @obenland Maybe you have an idea?

We'd need to add this to `shiny-updates.js` if we want to have that modal.

Fixes #187.