### PR TITLE
Add details link for theme updates on update-core.

### DIFF
--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -287,8 +287,21 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	 * @param array $item The current item.
 	 */
 	public function column_title_theme( $item ) {
+		static $themes_update = null;
+
 		/* @var WP_Theme $theme */
 		$theme = $item['data'];
+
+		if ( ! isset( $themes_update ) ) {
+			$themes_update = get_site_transient( 'update_themes' );
+		}
+
+		$details_url = add_query_arg( array(
+			'TB_iframe' => 'true',
+			'width'     => 640,
+			'height'    => 662,
+		), $themes_update->response[ $theme->get_stylesheet() ]['url'] );
+
 		?>
 		<div class="updates-table-screenshot">
 			<img src="<?php echo esc_url( $theme->get_screenshot() ); ?>" width="85" height="64" alt=""/>
@@ -296,10 +309,15 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 		<p>
 			<strong><?php echo $theme->display( 'Name' ); ?></strong>
 			<?php
+
 			/* translators: 1: theme version, 2: new version */
-			printf( __( 'You have version %1$s installed. Update to %2$s.' ),
+			printf( __( 'You have version %1$s installed. Update to %2$s. <a href="%3$s" class="thickbox open-plugin-details-modal" aria-label="%4$s" data-title="%5$s">View version %2$s details</a>.' ),
 				$theme->display( 'Version' ),
-				$theme->update['new_version']
+				$theme->update['new_version'],
+				esc_url( $details_url ),
+				/* translators: 1: theme name, 2: version number */
+				esc_attr( sprintf( __( 'View %1$s version %2$s details' ), $theme->display( 'Name' ), $theme->update['new_version'] ) ),
+				esc_attr( $theme->display( 'Name' ) )
 			);
 			?>
 		</p>

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -291,10 +291,12 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 		$theme = $item['data'];
 
 		$details_url = add_query_arg( array(
+			'tab'       => 'theme-information',
+			'theme'     => $theme->get_stylesheet(),
 			'TB_iframe' => 'true',
 			'width'     => 640,
 			'height'    => 662,
-		), $theme->update['url'] );
+		), admin_url( 'theme-install.php' ) );
 		?>
 		<div class="updates-table-screenshot">
 			<img src="<?php echo esc_url( $theme->get_screenshot() ); ?>" width="85" height="64" alt=""/>

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -295,7 +295,6 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 			'width'     => 640,
 			'height'    => 662,
 		), $theme->update['url'] );
-
 		?>
 		<div class="updates-table-screenshot">
 			<img src="<?php echo esc_url( $theme->get_screenshot() ); ?>" width="85" height="64" alt=""/>
@@ -303,7 +302,6 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 		<p>
 			<strong><?php echo $theme->display( 'Name' ); ?></strong>
 			<?php
-
 			/* translators: 1: theme version, 2: new version */
 			printf( __( 'You have version %1$s installed. Update to %2$s. <a href="%3$s" class="thickbox open-plugin-details-modal" aria-label="%4$s" data-title="%5$s">View version %2$s details</a>.' ),
 				$theme->display( 'Version' ),

--- a/src/class-shiny-updates-list-table.php
+++ b/src/class-shiny-updates-list-table.php
@@ -287,20 +287,14 @@ class Shiny_Updates_List_Table extends WP_List_Table {
 	 * @param array $item The current item.
 	 */
 	public function column_title_theme( $item ) {
-		static $themes_update = null;
-
 		/* @var WP_Theme $theme */
 		$theme = $item['data'];
-
-		if ( ! isset( $themes_update ) ) {
-			$themes_update = get_site_transient( 'update_themes' );
-		}
 
 		$details_url = add_query_arg( array(
 			'TB_iframe' => 'true',
 			'width'     => 640,
 			'height'    => 662,
-		), $themes_update->response[ $theme->get_stylesheet() ]['url'] );
+		), $theme->update['url'] );
 
 		?>
 		<div class="updates-table-screenshot">

--- a/src/functions.php
+++ b/src/functions.php
@@ -351,11 +351,23 @@ function su_theme_data( $themes ) {
 	$update = get_site_transient( 'update_themes' );
 	foreach ( $themes as $stylesheet => $theme ) {
 		if ( isset( $theme['hasUpdate'] ) && $theme['hasUpdate'] && current_user_can( 'update_themes' ) && ! empty( $update->response[ $stylesheet ] ) ) {
-			$themes[ $stylesheet ]['update'] = sprintf( '<p><strong>' . __( 'There is a new version of %1$s available. <a href="%2$s" class="thickbox open-plugin-details-modal" title="%3$s">View version %4$s details</a> or <a id="update-theme" data-slug="%5$s" href="%6$s">update now</a>.' ) . '</strong></p>', $theme['name'], esc_url( add_query_arg( array(
-				'TB_iframe' => 'true',
-				'width'     => 1024,
-				'height'    => 800,
-			), $update->response[ $stylesheet ]['url'] ) ), esc_attr( $theme['name'] ), $update->response[ $stylesheet ]['new_version'], $stylesheet, wp_nonce_url( admin_url( 'update.php?action=upgrade-theme&amp;theme=' . urlencode( $stylesheet ) ), 'upgrade-theme_' . $stylesheet ) );
+			$themes[ $stylesheet ]['update'] = sprintf(
+				/* translators: 1: theme name, 2: details URL, 3: escaped theme name, 4: version number, 5: theme slug, 6: update URL */
+				'<p><strong>' . __( 'There is a new version of %1$s available. <a href="%2$s" class="thickbox open-plugin-details-modal" title="%3$s" aria-label="View %3$s version %4$s details">View version %4$s details</a> or <a id="update-theme" data-slug="%5$s" href="%6$s">update now</a>.' ) . '</strong></p>',
+				$theme['name'],
+				esc_url( add_query_arg(
+					array(
+						'TB_iframe' => 'true',
+						'width'     => 1024,
+						'height'    => 800,
+					),
+					$update->response[ $stylesheet ]['url']
+				) ),
+				esc_attr( $theme['name'] ),
+				$update->response[ $stylesheet ]['new_version'],
+				$stylesheet,
+				wp_nonce_url( admin_url( 'update.php?action=upgrade-theme&amp;theme=' . urlencode( $stylesheet ) ), 'upgrade-theme_' . $stylesheet )
+			);
 		}
 	}
 


### PR DESCRIPTION
It currently shows a security error which doesn’t occur for plugin
details. I’m currently not sure how to resolve that.

Fixes #187.