### PR TITLE
Remove unneeded dismissible notices handler

### DIFF
--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -2043,34 +2043,6 @@
 		} );
 
 		/**
-		 * Make notices dismissible.
-		 *
-		 * @since 4.X.0
-		 */
-		$document.on( 'wp-updates-notice-added wp-theme-update-error wp-theme-install-error', function() {
-			$( '.notice.is-dismissible' ).each( function() {
-				var $notice = $( this ),
-				    $button = $( '<button type="button" class="notice-dismiss"><span class="screen-reader-text"></span></button>' ),
-				    /** @property {string} commonL10n.dismiss Dismiss message. */
-				    btnText = commonL10n.dismiss || '';
-
-				// Ensure plain text.
-				$button.find( '.screen-reader-text' ).text( btnText );
-				$button.on( 'click.wp-dismiss-notice', function( event ) {
-					event.preventDefault();
-
-					$notice.fadeTo( 100, 0, function() {
-						$notice.slideUp( 100, function() {
-							$notice.remove();
-						} );
-					} );
-				} );
-
-				$notice.append( $button );
-			} );
-		} );
-
-		/**
 		 * Handle changes to the plugin search box on the new-plugin page,
 		 * searching the repository dynamically.
 		 *

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -1,4 +1,5 @@
-/* global pagenow, commonL10n */
+/* global pagenow */
+
 /**
  *
  * @param {jQuery}  $                                   jQuery object.


### PR DESCRIPTION
WordPress already makes notices dismissible itself.

Fixes #210.