### PR TITLE
Make sure Core updates are processed last.

### DIFF
--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -1380,6 +1380,13 @@
 				break;
 
 			case 'update-core':
+
+				// Core updates should always come last to redirect to the about page.
+				if ( 0 !== wp.updates.updateQueue.length ) {
+					wp.updates.updateQueue.push( job );
+					return wp.updates.queueChecker();
+				}
+
 				wp.updates.updateCore( job.data );
 				break;
 


### PR DESCRIPTION
On bulk update all plugins are triggered simultaneously, resulting in
some being re-pushed to the queue, after a core update.

Fixes #228.