### PR TITLE
Improve position of the inline error notice for plugin delete failures

### DIFF
--- a/src/default-filters.php
+++ b/src/default-filters.php
@@ -19,6 +19,7 @@ add_action( 'admin_enqueue_scripts', 'su_enqueue_scripts' );
 
 // Add the update HTML for plugin updates progress.
 add_action( 'in_admin_header', 'su_admin_notice_template' );
+add_action( 'in_admin_header', 'su_plugin_update_row_template' );
 
 // Search plugins.
 add_action( 'wp_ajax_search-plugins', 'wp_ajax_search_plugins' );

--- a/src/functions.php
+++ b/src/functions.php
@@ -220,7 +220,7 @@ function su_admin_notice_template() {
 function su_plugin_update_row_template() {
 ?>
 <script id="tmpl-plugin-update-row" type="text/template">
-	<tr class="plugin-update-tr {{ type }}" id="{{ data.slug }}-{{ type }}" data-slug="{{ data.slug }}" data-plugin="{{ data.plugin }}">
+	<tr class="plugin-update-tr {{ data.type }}" id="{{ data.slug }}-{{ data.type }}" data-slug="{{ data.slug }}" data-plugin="{{ data.plugin }}">
 		<td colspan="{{ data.colspan }}" class="plugin-update colspanchange">
 			{{{ data.content }}}
 		</td>

--- a/src/functions.php
+++ b/src/functions.php
@@ -208,9 +208,9 @@ function su_admin_notice_template() {
  * param {object} data {
  *     Arguments for admin notice.
  *
- *     @type string id        ID of the notice.
- *     @type string className Class names for the notice.
- *     @type string message   The notice's message.
+ *     @type string slug    Plugin slug.
+ *     @type string plugin  Plugin folder and file name.
+ *     @type string content The update row content.
  * }
  *
  * @todo Merge: Perhaps add to to wp-admin/includes/update.php
@@ -220,7 +220,7 @@ function su_admin_notice_template() {
 function su_plugin_update_row_template() {
 ?>
 <script id="tmpl-plugin-update-row" type="text/template">
-	<tr class="plugin-update-tr {{ data.type }}" id="{{ data.slug }}-{{ data.type }}" data-slug="{{ data.slug }}" data-plugin="{{ data.plugin }}">
+	<tr class="plugin-update-tr update" id="{{ data.slug }}-update" data-slug="{{ data.slug }}" data-plugin="{{ data.plugin }}">
 		<td colspan="{{ data.colspan }}" class="plugin-update colspanchange">
 			{{{ data.content }}}
 		</td>

--- a/src/functions.php
+++ b/src/functions.php
@@ -201,6 +201,35 @@ function su_admin_notice_template() {
 }
 
 /**
+ * Adds the HTML template for plugin update rows on plugins.php.
+ *
+ * Template takes one argument with three values:
+ *
+ * param {object} data {
+ *     Arguments for admin notice.
+ *
+ *     @type string id        ID of the notice.
+ *     @type string className Class names for the notice.
+ *     @type string message   The notice's message.
+ * }
+ *
+ * @todo Merge: Perhaps add to to wp-admin/includes/update.php
+ *
+ * @since 4.X.0
+ */
+function su_plugin_update_row_template() {
+?>
+<script id="tmpl-plugin-update-row" type="text/template">
+	<tr class="plugin-update-tr {{{ type }}}" id="{{{ data.slug }}}-{{{ type }}}" data-slug="{{{ data.slug }}}" data-plugin="{{{ data.plugin }}}">
+		<td colspan="{{{ data.colspan }}}" class="plugin-update colspanchange">
+			{{{ data.content }}}
+		</td>
+	</tr>
+</script>
+<?php
+}
+
+/**
  * JavaScript theme template.
  *
  * @todo Merge: Replace template in wp-admin/themes.php

--- a/src/functions.php
+++ b/src/functions.php
@@ -220,8 +220,8 @@ function su_admin_notice_template() {
 function su_plugin_update_row_template() {
 ?>
 <script id="tmpl-plugin-update-row" type="text/template">
-	<tr class="plugin-update-tr {{{ type }}}" id="{{{ data.slug }}}-{{{ type }}}" data-slug="{{{ data.slug }}}" data-plugin="{{{ data.plugin }}}">
-		<td colspan="{{{ data.colspan }}}" class="plugin-update colspanchange">
+	<tr class="plugin-update-tr {{ type }}" id="{{ data.slug }}-{{ type }}" data-slug="{{ data.slug }}" data-plugin="{{ data.plugin }}">
+		<td colspan="{{ data.colspan }}" class="plugin-update colspanchange">
 			{{{ data.content }}}
 		</td>
 	</tr>

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -740,29 +740,35 @@
 	 * @param {string} response.errorMessage The error that occurred.
 	 */
 	wp.updates.deletePluginError = function( response ) {
-		var $plugin         = $( 'tr.inactive[data-plugin="' + response.plugin + '"]' ),
-		    pluginUpdateRow = wp.template( 'plugin-update-row' );
+		var $plugin          = $( 'tr.inactive[data-plugin="' + response.plugin + '"]' ),
+		    pluginUpdateRow  = wp.template( 'plugin-update-row' ),
+		    $pluginUpdateRow = $plugin.siblings( '#' + $plugin.data( 'slug' ) + '-update' ),
+		    noticeContent    = wp.updates.adminNotice( {
+			    className: 'update-message notice-error notice-alt',
+			    message:   response.errorMessage
+		    } );
 
 		if ( response.errorCode && 'unable_to_connect_to_filesystem' === response.errorCode ) {
 			wp.updates.credentialError( response, 'delete-plugin' );
 			return;
 		}
 
-		// Remove previous error messages, if any.
-		$plugin.siblings( '#' + $plugin.data( 'slug' ) + '-error' ).remove();
-
-		$plugin.after(
-			pluginUpdateRow( {
-				slug:    $plugin.data( 'slug' ),
-				plugin:  response.plugin,
-				type:    'error',
-				colspan: $( '#bulk-action-form' ).find( 'thead th:not(.hidden), thead td' ).length,
-				content: wp.updates.adminNotice( {
-					className: 'update-message notice-error notice-alt',
-					message:   response.errorMessage
+		// Add a plugin update row if it doesn't exist yet.
+		if ( ! $pluginUpdateRow.length ) {
+			$plugin.addClass( 'update' ).after(
+				pluginUpdateRow( {
+					slug:    $plugin.data( 'slug' ),
+					plugin:  response.plugin,
+					colspan: $( '#bulk-action-form' ).find( 'thead th:not(.hidden), thead td' ).length,
+					content: noticeContent
 				} )
-			} )
-		);
+			);
+		} else {
+			// Remove previous error messages, if any.
+			$pluginUpdateRow.find( '.notice-error' ).remove();
+
+			$pluginUpdateRow.find( '.plugin-update' ).append( noticeContent );
+		}
 
 		$document.trigger( 'wp-plugin-delete-error', response );
 	};

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -740,15 +740,28 @@
 	 * @param {string} response.errorMessage The error that occurred.
 	 */
 	wp.updates.deletePluginError = function( response ) {
+		var $plugin         = $( 'tr.inactive[data-plugin="' + response.plugin + '"]' ),
+		    pluginUpdateRow = wp.template( 'plugin-update-row' );
+
 		if ( response.errorCode && 'unable_to_connect_to_filesystem' === response.errorCode ) {
 			wp.updates.credentialError( response, 'delete-plugin' );
 			return;
 		}
 
-		$( 'tr[data-plugin="' + response.plugin + '"]' ).find( '.column-description' ).prepend( wp.updates.adminNotice( {
-			className: 'update-message notice-error notice-alt',
-			message:   response.errorMessage
-		} ) );
+		if ( !$plugin.siblings( '#' + $plugin.data( 'slug' ) + '-error' ).length ) {
+			$plugin.after(
+				pluginUpdateRow( {
+					slug:    $plugin.data( 'slug' ),
+					plugin:  response.plugin,
+					type:    'error',
+					colspan: $( '#bulk-action-form' ).find( 'thead th:not(.hidden), thead td' ).length,
+					content: wp.updates.adminNotice( {
+						className: 'update-message notice-error notice-alt',
+						message:   response.errorMessage
+					} )
+				} )
+			)
+		}
 
 		$document.trigger( 'wp-plugin-delete-error', response );
 	};

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -760,7 +760,7 @@
 						message:   response.errorMessage
 					} )
 				} )
-			)
+			);
 		}
 
 		$document.trigger( 'wp-plugin-delete-error', response );

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -748,20 +748,21 @@
 			return;
 		}
 
-		if ( !$plugin.siblings( '#' + $plugin.data( 'slug' ) + '-error' ).length ) {
-			$plugin.after(
-				pluginUpdateRow( {
-					slug:    $plugin.data( 'slug' ),
-					plugin:  response.plugin,
-					type:    'error',
-					colspan: $( '#bulk-action-form' ).find( 'thead th:not(.hidden), thead td' ).length,
-					content: wp.updates.adminNotice( {
-						className: 'update-message notice-error notice-alt',
-						message:   response.errorMessage
-					} )
+		// Remove previous error messages, if any.
+		$plugin.siblings( '#' + $plugin.data( 'slug' ) + '-error' ).remove();
+
+		$plugin.after(
+			pluginUpdateRow( {
+				slug:    $plugin.data( 'slug' ),
+				plugin:  response.plugin,
+				type:    'error',
+				colspan: $( '#bulk-action-form' ).find( 'thead th:not(.hidden), thead td' ).length,
+				content: wp.updates.adminNotice( {
+					className: 'update-message notice-error notice-alt',
+					message:   response.errorMessage
 				} )
-			);
-		}
+			} )
+		);
 
 		$document.trigger( 'wp-plugin-delete-error', response );
 	};


### PR DESCRIPTION
Demo:

<img width="607" alt="screen shot 2016-06-04 at 17 11 39" src="https://cloud.githubusercontent.com/assets/841956/15800382/97c16670-2a77-11e6-9b54-d024427fa8da.png">
<img width="766" alt="screen shot 2016-06-04 at 17 11 30" src="https://cloud.githubusercontent.com/assets/841956/15800383/97d89944-2a77-11e6-8b71-96db9f738f8c.png">

Fixes #232.
