### PR TITLE
Add a success message after deleting a plugin

### DIFF
--- a/src/css/shiny-updates.css
+++ b/src/css/shiny-updates.css
@@ -135,6 +135,14 @@ tr.active.update + tr.plugin-update-tr .plugin-update {
 	margin: auto;
 }
 
+.plugins .plugin-deleted-tr {
+	background: #f5f5f5;
+}
+
+.plugins .deleted td {
+	padding: 10px 10px 10px 15px;
+}
+
 @media screen and (max-width: 782px) {
 	.plugins .active.update + .plugin-update-tr:before {
 		background-color: #f7fcfe;

--- a/src/functions.php
+++ b/src/functions.php
@@ -226,6 +226,19 @@ function su_plugin_update_row_template() {
 		</td>
 	</tr>
 </script>
+<script id="tmpl-plugin-deleted-row" type="text/template">
+	<tr class="plugin-deleted-tr inactive deleted" id="{{ data.slug }}-deleted" data-slug="{{ data.slug }}" data-plugin="{{ data.plugin }}">
+		<td colspan="{{ data.colspan }}" class="plugin-update colspanchange">
+			<?php
+				printf(
+					/* translators: %s: Plugin name */
+					__( 'The plugin %s was successfully deleted'),
+					'<strong>{{{ data.pluginName }}}</strong>'
+				);
+			?>
+		</td>
+	</tr>
+</script>
 <?php
 }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -232,7 +232,7 @@ function su_plugin_update_row_template() {
 			<?php
 				printf(
 					/* translators: %s: Plugin name */
-					__( 'The plugin %s was successfully deleted'),
+					__( 'The plugin %s was successfully deleted.' ),
 					'<strong>{{{ data.pluginName }}}</strong>'
 				);
 			?>

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -661,32 +661,35 @@
 	 * @since 4.X.0
 	 *
 	 * @typedef {object} deletePluginSuccess
-	 * @param {object} response        Response from the server.
-	 * @param {string} response.slug   Slug of the plugin to be deleted.
-	 * @param {string} response.plugin Basename of the plugin to be deleted.
+	 * @param {object} response            Response from the server.
+	 * @param {string} response.slug       Slug of the plugin that was deleted.
+	 * @param {string} response.plugin     Basename of the plugin that was deleted.
+	 * @param {string} response.pluginName Name of the plugin that was deleted.
 	 */
 	wp.updates.deletePluginSuccess = function( response ) {
+
 		// Removes the plugin and updates rows.
 		$( '[data-plugin="' + response.plugin + '"]' ).css( { backgroundColor: '#faafaa' } ).fadeOut( 350, function() {
 			var $form            = $( '#bulk-action-form' ),
 			    $views           = $( '.subsubsub' ),
+				$pluginRow       = $( this ),
 			    columnCount      = $form.find( 'thead th:not(.hidden), thead td' ).length,
 			    pluginDeletedRow = wp.template( 'plugin-deleted-row' ),
 			    /** @type {object} plugins Base names of plugins in their different states. */
 			    plugins          = settings.plugins;
 
-			if ( ! $( this ).hasClass( 'plugin-update-tr' ) ) {
-				$( this ).after(
+			if ( ! $pluginRow.hasClass( 'plugin-update-tr' ) ) {
+				$pluginRow.after(
 					pluginDeletedRow( {
 						slug:       response.slug,
 						plugin:     response.plugin,
-						colspan:    $form.find( 'thead th:not(.hidden), thead td' ).length,
-						pluginName: $( this ).find( '.plugin-title strong' ).text()
+						colspan:    columnCount,
+						pluginName: response.pluginName
 					} )
 				);
 			}
 
-			$( this ).remove();
+			$pluginRow.remove();
 
 			// Remove plugin from update count.
 			if ( -1 !== _.indexOf( plugins.upgrade, response.plugin ) ) {
@@ -775,6 +778,7 @@
 				} )
 			);
 		} else {
+
 			// Remove previous error messages, if any.
 			$pluginUpdateRow.find( '.notice-error' ).remove();
 

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -672,7 +672,7 @@
 		$( '[data-plugin="' + response.plugin + '"]' ).css( { backgroundColor: '#faafaa' } ).fadeOut( 350, function() {
 			var $form            = $( '#bulk-action-form' ),
 			    $views           = $( '.subsubsub' ),
-				$pluginRow       = $( this ),
+			    $pluginRow       = $( this ),
 			    columnCount      = $form.find( 'thead th:not(.hidden), thead td' ).length,
 			    pluginDeletedRow = wp.template( 'plugin-deleted-row' ),
 			    /** @type {object} plugins Base names of plugins in their different states. */

--- a/src/js/shiny-updates.js
+++ b/src/js/shiny-updates.js
@@ -666,14 +666,25 @@
 	 * @param {string} response.plugin Basename of the plugin to be deleted.
 	 */
 	wp.updates.deletePluginSuccess = function( response ) {
-
 		// Removes the plugin and updates rows.
 		$( '[data-plugin="' + response.plugin + '"]' ).css( { backgroundColor: '#faafaa' } ).fadeOut( 350, function() {
-			var $form       = $( '#bulk-action-form' ),
-			    $views      = $( '.subsubsub' ),
-			    columnCount = $form.find( 'thead th:not(.hidden), thead td' ).length,
+			var $form            = $( '#bulk-action-form' ),
+			    $views           = $( '.subsubsub' ),
+			    columnCount      = $form.find( 'thead th:not(.hidden), thead td' ).length,
+			    pluginDeletedRow = wp.template( 'plugin-deleted-row' ),
 			    /** @type {object} plugins Base names of plugins in their different states. */
-			    plugins     = settings.plugins;
+			    plugins          = settings.plugins;
+
+			if ( ! $( this ).hasClass( 'plugin-update-tr' ) ) {
+				$( this ).after(
+					pluginDeletedRow( {
+						slug:       response.slug,
+						plugin:     response.plugin,
+						colspan:    $form.find( 'thead th:not(.hidden), thead td' ).length,
+						pluginName: $( this ).find( '.plugin-title strong' ).text()
+					} )
+				);
+			}
 
 			$( this ).remove();
 


### PR DESCRIPTION
The message looks similar to the one you get when trashing comments.

Demo:

![delete-plugin](https://cloud.githubusercontent.com/assets/841956/15820843/553a2fe6-2bec-11e6-836c-3ef975b250b3.gif)

Fixes #202.