### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+* text=auto
+
+.codeclimate.yml export-ignore
+.csslintrc export-ignore
+.editorconfig export-ignore
+.eslintignore export-ignore
+.eslintrc export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.jscsrc export-ignore
+.jshintignore export-ignore
+.jshintrc export-ignore
+.travis.yml export-ignore
+codesniffer.ruleset.xml export-ignore
+composer.json export-ignore
+composer.lock export-ignore
+Gruntfile.js export-ignore
+package.json export-ignore


### PR DESCRIPTION
Add .gitattributes file. This should eliminate unessential files from a GitHub download.